### PR TITLE
feat: fix typo metro.confgi.js to metro.config.js

### DIFF
--- a/apps/website/docs/quick-starts/expo.md
+++ b/apps/website/docs/quick-starts/expo.md
@@ -93,7 +93,7 @@ module.exports = function (api) {
 ## 6. Enable CSS Support in Expo's Metro Config
 
 ```js
-// metro.confgi.js
+// metro.config.js
 const { getDefaultConfig } = require("expo/metro-config");
 
 const config = getDefaultConfig(__dirname, {


### PR DESCRIPTION
![image](https://github.com/marklawlor/nativewind/assets/96602536/7069b230-0580-41ba-b62a-19f00e545d4b)

Fixed this typo in expo router section