### PR TITLE
docs: Add Tailwind version to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 <img alt="npm" src="https://img.shields.io/npm/v/nativewind">
 <img alt="npm" src="https://img.shields.io/npm/dt/nativewind">
 <img alt="GitHub" src="https://img.shields.io/github/license/marklawlor/nativewind">
+<img src="https://img.shields.io/badge/Tailwind-3.3.3-blue">
 </div>
 <br />
 


### PR DESCRIPTION
Hi,

New to this repo and I found that it was a bit difficult to see which version of Tailwind does this library support.

I think it would be nice to add a badge or somewhere in doc to clearly state that.

I have made a simple static badge but there're a few problems:

1. I'm not sure if this is accurate, I dug into the folders and found it in `packages/nativewind/package.json` as devDep. If someone more experienced with the repo can chime in that'll be great.

2. Ideally this should be dynamic so that whenever we bump Tailwind version it will still be in sync