### PR TITLE
Fix props like backgroundStyle

### DIFF
--- a/packages/react-native-css-interop/src/runtime/native/style.ts
+++ b/packages/react-native-css-interop/src/runtime/native/style.ts
@@ -780,7 +780,7 @@ export function reduceStyles(
     }
 
     if (style.props) {
-      for (const [prop, value] of style.props) {
+      for (const [_prop, value] of style.props) {
         if (typeof value === "object" && "$$type" in value) {
           state.props[prop] = value.value;
         } else if (value !== undefined) {


### PR DESCRIPTION
I think extra props broken with the rewrite style.ts.

With something like
```ts
cssInterop(BottomSheetModal, {                                                                                                                                                                                                                
  backgroundClass: 'backgroundStyle',                                                                                                                                                                                                         
});      

`backgroundStyle` would never appear in the props, instead everything would be added to the style prop.

It looks like a variable shadowing issue in the code