### PR TITLE
Fix typo in babel plugin test description

### DIFF
--- a/packages/react-native-css-interop/src/__tests__/babel-plugin.ts
+++ b/packages/react-native-css-interop/src/__tests__/babel-plugin.ts
@@ -99,7 +99,7 @@ export default function App() {
 }`,
       babelOptions: { filename: "/someFile.js" },
     },
-    "createELement from 3rd party": {
+    "createElement from 3rd party": {
       code: `import { createElement } from "other-lib";
 export default function App() {
   return createElement("div", {}, "Hello World");


### PR DESCRIPTION
Thank you for awesome project!

I'm personally working on migrating a nativewind's babel plugin to [swc](https://swc.rs) plugin([swc-plugin-nativewind](https://github.com/leegeunhyeok/swc-plugin-nativewind)), and I came across a wrong case typo.

**Changes**: only fixes case typos found.

```bash
npx turbo test --filter react-native-css-interop
```

<img width="962" alt="image" src="https://github.com/marklawlor/nativewind/assets/26512984/eb630b1d-953b-4902-ab00-501e3791100a">
