### PR TITLE
Update typescript.md

### DIFF
--- a/apps/website/versioned_docs/version-v2/getting-started/typescript.md
+++ b/apps/website/versioned_docs/version-v2/getting-started/typescript.md
@@ -1,6 +1,6 @@
 # Typescript
 
-NativeWind extends the React Native types via declaration merging. The simplest method to include the types is to create a new `app.d.ts` file and add a [triple-slash directive](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html) referencing the types.
+NativeWind extends the React Native types via declaration merging. The simplest method to include the types is to create a new `global.d.ts` file and add a [triple-slash directive](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html) referencing the types.
 
 ```tsx
 /// <reference types="nativewind/types" />


### PR DESCRIPTION
After a recent update, `app.d.ts` is no longer working so renamed it to `global.d.ts`.

Referenced here:
https://github.com/kristerkari/react-native-css-modules-with-typescript-example/issues/3#issuecomment-1532988999