### PR TITLE
Fix tailwind cli path error

### DIFF
--- a/packages/nativewind/src/metro/index.ts
+++ b/packages/nativewind/src/metro/index.ts
@@ -35,11 +35,11 @@ export function withNativeWind(
     projectRoot = process.cwd(),
     inlineRem = 14,
     configPath: tailwindConfigPath = "tailwind.config.js",
-    cliCommand = `node ${path.join(
+    cliCommand = `node "${path.join(
       require.resolve("tailwindcss/package.json"),
       "../",
       tailwindPackage.bin.tailwindcss,
-    )}`,
+    )}"`,
     browserslist = "last 1 version",
     browserslistEnv = "native",
   }: WithNativeWindOptions = {} as WithNativeWindOptions,


### PR DESCRIPTION
This should fix the cli error by passing the cli path as a string.

I had the same issue as #813 and executed the tw cli directly. I noticed that the blank spaces were not escaped in the cli path which the error gave me. The referenced issue also shows an error with a path which has a blank space.

Only tested this on mac so unix works, but can't test windows.

This should close #813.

