### PR TITLE
Escape windows path during metro transform

### DIFF
--- a/packages/nativewind/src/metro/transformer.ts
+++ b/packages/nativewind/src/metro/transformer.ts
@@ -22,7 +22,7 @@ export async function transform(
         config,
         projectRoot,
         filename,
-        Buffer.from(`require('${config.nativewind.output}');`, "utf8"),
+        Buffer.from(`require('${config.nativewind.output.replace(/\\/g, '\\\\')}');`, "utf8"),
         options,
       );
     } else {


### PR DESCRIPTION
Resubmitting [this fix](https://github.com/marklawlor/nativewind/pull/743) for #610 since it has been removed by various changes in the meantime; specifically [this commit](https://github.com/marklawlor/nativewind/commit/72ff611cc4fb08ca9e6265d6e1496e4b64a7de78#diff-3b3d28940d6e4a5ad11860e5a017afef5641e4f9becc71e403a638a77ed76539R24)

Needed for windows web build.
