### PR TITLE
fix: Ensure Windows path compatibility in web platform transformation

### DIFF
--- a/packages/nativewind/src/metro/transformer.ts
+++ b/packages/nativewind/src/metro/transformer.ts
@@ -17,12 +17,14 @@ export async function transform(
 ): Promise<TransformResponse> {
   if (path.resolve(process.cwd(), filename) === config.nativewind.input) {
     if (options.platform === "web") {
+      const windowsCompatibleOutputPath = config.nativewind.output.replace(/\\/g, '\\\\');
+
       // Frameworks like Expo correctly handle the CSS, so just redirect to the Tailwind generated file
       return worker.transform(
         config,
         projectRoot,
         filename,
-        Buffer.from(`require('${config.nativewind.output}');`, "utf8"),
+        Buffer.from(`require('${windowsCompatibleOutputPath}');`, "utf8"),
         options,
       );
     } else {


### PR DESCRIPTION
This PR fixes an issue where Windows paths were not correctly handled in the Metro transformer's web platform transformation, causing incorrect runtime module resolution.

It's a duplicate of https://github.com/marklawlor/nativewind/pull/854, but with a better naming so we don't break it again. ❗ 

@marklawlor could you please merge it ASAP as we're using `nativewind` in production and we hate to patch it :)

 The related issue - https://github.com/marklawlor/nativewind/issues/784#issuecomment-2018604499