### PR TITLE
fix: allow patching of react.createElement

### DIFF
--- a/packages/react-native-css-interop/src/__tests__/babel-plugin.test.ts
+++ b/packages/react-native-css-interop/src/__tests__/babel-plugin.test.ts
@@ -17,10 +17,13 @@ pluginTester({
 export default function App() {
   return /*#__PURE__*/ _react.default.createElement(_reactNative.Text, {})
 }`,
-      output: `import { createInteropElement as _createInteropElement } from "react-native-css-interop";
+      output: `import * as __ReactNativeCSSInterop from "react-native-css-interop";
 var _react = _interopRequireDefault(require("react"));
 export default function App() {
-  return /*#__PURE__*/ _createInteropElement(_reactNative.Text, {});
+  return /*#__PURE__*/ __ReactNativeCSSInterop.createInteropElement(
+    _reactNative.Text,
+    {}
+  );
 }`,
       babelOptions: { filename: "/someFile.js" },
     },
@@ -29,10 +32,10 @@ export default function App() {
 export default function App() {
   return createElement("div", {}, "Hello World");
 }`,
-      output: `import { createInteropElement as _createInteropElement } from "react-native-css-interop";
+      output: `import * as __ReactNativeCSSInterop from "react-native-css-interop";
 import { createElement } from "react";
 export default function App() {
-  return _createInteropElement("div", {}, "Hello World");
+  return __ReactNativeCSSInterop.createInteropElement("div", {}, "Hello World");
 }`,
 
       babelOptions: { filename: "/someFile.js" },
@@ -42,10 +45,10 @@ export default function App() {
 export default function App() {
   return React.createElement("div", {}, "Hello World");
 }`,
-      output: `import { createInteropElement as _createInteropElement } from "react-native-css-interop";
+      output: `import * as __ReactNativeCSSInterop from "react-native-css-interop";
 import React from "react";
 export default function App() {
-  return _createInteropElement("div", {}, "Hello World");
+  return __ReactNativeCSSInterop.createInteropElement("div", {}, "Hello World");
 }`,
 
       babelOptions: { filename: "/someFile.js" },
@@ -56,10 +59,10 @@ export default function App() {
 export default function App() {
   return createElement("div", {}, "Hello World");
 }`,
-      output: `import { createInteropElement as _createInteropElement } from "react-native-css-interop";
+      output: `import * as __ReactNativeCSSInterop from "react-native-css-interop";
 const { createElement } = require("react");
 export default function App() {
-  return _createInteropElement("div", {}, "Hello World");
+  return __ReactNativeCSSInterop.createInteropElement("div", {}, "Hello World");
 }`,
       babelOptions: { filename: "/someFile.js" },
     },
@@ -68,10 +71,10 @@ export default function App() {
 export default function App() {
   return React.createElement("div", {}, "Hello World");
 }`,
-      output: `import { createInteropElement as _createInteropElement } from "react-native-css-interop";
+      output: `import * as __ReactNativeCSSInterop from "react-native-css-interop";
 import * as React from "react";
 export default function App() {
-  return _createInteropElement("div", {}, "Hello World");
+  return __ReactNativeCSSInterop.createInteropElement("div", {}, "Hello World");
 }`,
       babelOptions: { filename: "/someFile.js" },
     },
@@ -80,10 +83,10 @@ export default function App() {
 export default function App() {
   return react.createElement("div", {}, "Hello World");
 }`,
-      output: `import { createInteropElement as _createInteropElement } from "react-native-css-interop";
+      output: `import * as __ReactNativeCSSInterop from "react-native-css-interop";
 import * as react from "react";
 export default function App() {
-  return _createInteropElement("div", {}, "Hello World");
+  return __ReactNativeCSSInterop.createInteropElement("div", {}, "Hello World");
 }`,
       babelOptions: { filename: "/someFile.js" },
     },
@@ -92,10 +95,10 @@ export default function App() {
 export default function App() {
   return react.createElement("div", {}, "Hello World");
 }`,
-      output: `import { createInteropElement as _createInteropElement } from "react-native-css-interop";
+      output: `import * as __ReactNativeCSSInterop from "react-native-css-interop";
 var react = require("react");
 export default function App() {
-  return _createInteropElement("div", {}, "Hello World");
+  return __ReactNativeCSSInterop.createInteropElement("div", {}, "Hello World");
 }`,
       babelOptions: { filename: "/someFile.js" },
     },
@@ -121,6 +124,30 @@ export default function App() {
 }`,
       babelOptions: {
         filename: "/node_modules/react-native-css-interop/someFile.js",
+      },
+    },
+    "patch React.createElement syntax": {
+      code: `import * as React from "react";
+export default function App() {
+  const originalCreateElement = React.createElement;
+  return React.createElement = (type, props, ...children) => {
+    return originalCreateElement(type, props, ...children);
+  };
+}`,
+      output: `import * as __ReactNativeCSSInterop from "react-native-css-interop";
+import * as React from "react";
+export default function App() {
+  const originalCreateElement = __ReactNativeCSSInterop.createInteropElement;
+  return (__ReactNativeCSSInterop.createInteropElement = (
+    type,
+    props,
+    ...children
+  ) => {
+    return originalCreateElement(type, props, ...children);
+  });
+}`,
+      babelOptions: {
+        filename: "/somefile.js",
       },
     },
   },

--- a/packages/react-native-css-interop/src/__tests__/babel-plugin.test.ts
+++ b/packages/react-native-css-interop/src/__tests__/babel-plugin.test.ts
@@ -17,10 +17,10 @@ pluginTester({
 export default function App() {
   return /*#__PURE__*/ _react.default.createElement(_reactNative.Text, {})
 }`,
-      output: `import * as __ReactNativeCSSInterop from "react-native-css-interop";
+      output: `import * as _ReactNativeCSSInterop from "react-native-css-interop";
 var _react = _interopRequireDefault(require("react"));
 export default function App() {
-  return /*#__PURE__*/ __ReactNativeCSSInterop.createInteropElement(
+  return /*#__PURE__*/ _ReactNativeCSSInterop.createInteropElement(
     _reactNative.Text,
     {}
   );
@@ -32,10 +32,10 @@ export default function App() {
 export default function App() {
   return createElement("div", {}, "Hello World");
 }`,
-      output: `import * as __ReactNativeCSSInterop from "react-native-css-interop";
+      output: `import * as _ReactNativeCSSInterop from "react-native-css-interop";
 import { createElement } from "react";
 export default function App() {
-  return __ReactNativeCSSInterop.createInteropElement("div", {}, "Hello World");
+  return _ReactNativeCSSInterop.createInteropElement("div", {}, "Hello World");
 }`,
 
       babelOptions: { filename: "/someFile.js" },
@@ -45,10 +45,10 @@ export default function App() {
 export default function App() {
   return React.createElement("div", {}, "Hello World");
 }`,
-      output: `import * as __ReactNativeCSSInterop from "react-native-css-interop";
+      output: `import * as _ReactNativeCSSInterop from "react-native-css-interop";
 import React from "react";
 export default function App() {
-  return __ReactNativeCSSInterop.createInteropElement("div", {}, "Hello World");
+  return _ReactNativeCSSInterop.createInteropElement("div", {}, "Hello World");
 }`,
 
       babelOptions: { filename: "/someFile.js" },
@@ -59,10 +59,10 @@ export default function App() {
 export default function App() {
   return createElement("div", {}, "Hello World");
 }`,
-      output: `import * as __ReactNativeCSSInterop from "react-native-css-interop";
+      output: `import * as _ReactNativeCSSInterop from "react-native-css-interop";
 const { createElement } = require("react");
 export default function App() {
-  return __ReactNativeCSSInterop.createInteropElement("div", {}, "Hello World");
+  return _ReactNativeCSSInterop.createInteropElement("div", {}, "Hello World");
 }`,
       babelOptions: { filename: "/someFile.js" },
     },
@@ -71,10 +71,10 @@ export default function App() {
 export default function App() {
   return React.createElement("div", {}, "Hello World");
 }`,
-      output: `import * as __ReactNativeCSSInterop from "react-native-css-interop";
+      output: `import * as _ReactNativeCSSInterop from "react-native-css-interop";
 import * as React from "react";
 export default function App() {
-  return __ReactNativeCSSInterop.createInteropElement("div", {}, "Hello World");
+  return _ReactNativeCSSInterop.createInteropElement("div", {}, "Hello World");
 }`,
       babelOptions: { filename: "/someFile.js" },
     },
@@ -83,10 +83,10 @@ export default function App() {
 export default function App() {
   return react.createElement("div", {}, "Hello World");
 }`,
-      output: `import * as __ReactNativeCSSInterop from "react-native-css-interop";
+      output: `import * as _ReactNativeCSSInterop from "react-native-css-interop";
 import * as react from "react";
 export default function App() {
-  return __ReactNativeCSSInterop.createInteropElement("div", {}, "Hello World");
+  return _ReactNativeCSSInterop.createInteropElement("div", {}, "Hello World");
 }`,
       babelOptions: { filename: "/someFile.js" },
     },
@@ -95,10 +95,10 @@ export default function App() {
 export default function App() {
   return react.createElement("div", {}, "Hello World");
 }`,
-      output: `import * as __ReactNativeCSSInterop from "react-native-css-interop";
+      output: `import * as _ReactNativeCSSInterop from "react-native-css-interop";
 var react = require("react");
 export default function App() {
-  return __ReactNativeCSSInterop.createInteropElement("div", {}, "Hello World");
+  return _ReactNativeCSSInterop.createInteropElement("div", {}, "Hello World");
 }`,
       babelOptions: { filename: "/someFile.js" },
     },
@@ -134,11 +134,11 @@ export default function App() {
     return originalCreateElement(type, props, ...children);
   };
 }`,
-      output: `import * as __ReactNativeCSSInterop from "react-native-css-interop";
+      output: `import * as _ReactNativeCSSInterop from "react-native-css-interop";
 import * as React from "react";
 export default function App() {
-  const originalCreateElement = __ReactNativeCSSInterop.createInteropElement;
-  return (__ReactNativeCSSInterop.createInteropElement = (
+  const originalCreateElement = _ReactNativeCSSInterop.createInteropElement;
+  return (_ReactNativeCSSInterop.createInteropElement = (
     type,
     props,
     ...children

--- a/packages/react-native-css-interop/src/babel-plugin.ts
+++ b/packages/react-native-css-interop/src/babel-plugin.ts
@@ -11,15 +11,12 @@ import {
   identifier
 } from "@babel/types";
 import { Binding, NodePath } from "@babel/traverse";
-import template from "@babel/template";
+import { addNamespace } from "@babel/helper-module-imports";
 
 const importFunction = "createInteropElement";
 const importModule = "react-native-css-interop";
-const importAs = "__ReactNativeCSSInterop";
+const importAs = "ReactNativeCSSInterop";
 
-const importAst = template(`
-  import * as ${importAs} from "${importModule}";
-`)();
 
 const allowedFileRegex =
   /^(?!.*[\/\\](react|react-native|react-native-web|react-native-css-interop)[\/\\]).*$/;
@@ -33,9 +30,9 @@ export default function () {
           let newExpression: null | MemberExpression = null;
           const insertImportStatement = () => {
             if (newExpression === null) {
-              path.unshiftContainer("body",importAst);
+              const importAsIdentifier = addNamespace(path, importModule, { nameHint: importAs })
               newExpression = memberExpression(
-                identifier(importAs),
+                importAsIdentifier,
                 identifier(importFunction)
               );
             }

--- a/packages/react-native-css-interop/src/babel-plugin.ts
+++ b/packages/react-native-css-interop/src/babel-plugin.ts
@@ -51,7 +51,6 @@ export default function () {
 const visitor = {
   MemberExpression(path: NodePath<MemberExpression>, state: {insertImportStatement: () => MemberExpression, filename: string}) {
     if (
-      allowedFileRegex.test(state.filename) &&
       isIdentifier(path.node.property, { name: "createElement" })
     ) {
       let shouldReplace = false;
@@ -82,7 +81,6 @@ const visitor = {
   },
   Identifier(path: NodePath<Identifier>, state: {insertImportStatement: () => MemberExpression, filename: string}) {
     if (
-      allowedFileRegex.test(state.filename) &&
       path.node.name === "createElement" &&
       path.parentPath.isCallExpression() &&
       isImportedFromReact(path.scope.getBinding("createElement"))

--- a/packages/react-native-css-interop/src/babel-plugin.ts
+++ b/packages/react-native-css-interop/src/babel-plugin.ts
@@ -37,7 +37,7 @@ export default function () {
               newExpression = memberExpression(
                 identifier(importAs),
                 identifier(importFunction)
-              );;
+              );
             }
             return newExpression
           }

--- a/packages/react-native-css-interop/src/babel-plugin.ts
+++ b/packages/react-native-css-interop/src/babel-plugin.ts
@@ -25,7 +25,7 @@ export default function () {
   return {
     name: "react-native-css-interop-imports",
     visitor: {
-      Program(path: NodePath<Program>, state: any) {
+      Program(path: NodePath<Program>, state: { filename: string }) {
         if (allowedFileRegex.test(state.filename)) {
           let newExpression: null | MemberExpression = null;
           const insertImportStatement = () => {


### PR DESCRIPTION
## Issue
Analytics libraries like datadog patch `React.createElement` to override onPress prop for tracking. [Here](https://github.com/DataDog/dd-sdk-reactnative/blob/5b8a26c61afc7c454c180fdc44ac23168733c682/packages/core/src/rum/instrumentation/interactionTracking/DdRumUserInteractionTracking.tsx#L31)

Although, not a huge fan of the approach taken here by the datadog library as alternate solutions exist. But I think `react-native-css-interop` should support such a usecase as the original `React.createElement` doesn't prevent patching.

## Approach
RN CSS interop uses named import `createInteropElement` to replace `createElement`, this prevents patching, as babel transpiles such imports to read-only. The approach taken in this PR is to use namespace imports. e.g. `createElement` will become `ReactNativeCSSInterop.createInteropElement`. Such an import is not considered read-only and users can perform patching `ReactNativeCSSInterop.createInteropElement = () => {}`


## Note
This PR is a partial solution to allow patching `React.createElement`. NativeWind's current `tsc` approach to build distribution packages generates below output. This output lacks ability to mutate `createInteropElement` as it only has a getter in `Object.define`, no `writable`. I think we should distribute packages with `esnext` module preset in tsconfig or use expo module scripts for distribution builds. Would love to know your thoughts on this.

<img width="500" alt="Screenshot 2024-04-29 at 8 56 16 PM" src="https://github.com/marklawlor/nativewind/assets/23293248/cab2a275-b3b5-4fc7-9ea5-7a9556381966">
