### PR TITLE
Add typescript considerations

### DIFF
--- a/apps/website/versioned_docs/version-v2/quick-starts/expo.md
+++ b/apps/website/versioned_docs/version-v2/quick-starts/expo.md
@@ -56,6 +56,16 @@ module.exports = function (api) {
 
 ```
 
+## 4. Typescript
+
+If your project uses typescript, you'll need to reference the nativewind types in a declaration file in the root of your project folder:
+
+```
+/** index.d.ts */
+
+/// <reference types="nativewind/types" />
+```
+
 <StartCoding />
 
 ## Expo Web


### PR DESCRIPTION
Added a #4 second level heading explaining the need to reference nativewind types in a root type declaration file.