### PR TITLE
Fix five typos in documentation and landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 </div>
 <br />
 
-`NativeWind` uses [Tailwind CSS](https://tailwindcss.com) as high-level scripting language to create a **universal design system**. Styled components can be shared between all React Native platforms, using the best style engine for that platform (e.g. CSS StyleSheet or StyleSheet.create). It's goals are to to provide a consistent styling experience across all platforms, improving Developer UX, component performance and code maintainability.
+`NativeWind` uses [Tailwind CSS](https://tailwindcss.com) as high-level scripting language to create a **universal design system**. Styled components can be shared between all React Native platforms, using the best style engine for that platform (e.g. CSS StyleSheet or StyleSheet.create). Its goals are to to provide a consistent styling experience across all platforms, improving Developer UX, component performance and code maintainability.
 
 `NativeWind` processes your styles during your application build, and uses a minimal runtime to selectively apply reactive styles (eg changes to device orientation, light dark mode).
 

--- a/apps/website/docs/overview/overview.md
+++ b/apps/website/docs/overview/overview.md
@@ -2,7 +2,7 @@
 
 ## What is NativeWind?
 
-NativeWind allows you to use [Tailwind CSS](https://tailwindcss.com) to style your components in React Native. Styled components can be shared between all React Native platforms, using the best style engine for that platform; CSS StyleSheet on web and StyleSheet.create for native. It's goals are to provide a consistent styling experience across all platforms, improving Developer UX, component performance and code maintainability.
+NativeWind allows you to use [Tailwind CSS](https://tailwindcss.com) to style your components in React Native. Styled components can be shared between all React Native platforms, using the best style engine for that platform; CSS StyleSheet on web and StyleSheet.create for native. Its goals are to provide a consistent styling experience across all platforms, improving Developer UX, component performance and code maintainability.
 
 On native platforms, NativeWind performs two functions. First, at build time, it compiles your Tailwind CSS styles into `StyleSheet.create` objects and determines the conditional logic of styles (e.g. hover, focus, active, etc). Second, it has an efficient runtime system that applies the styles to your components. This means you can use the full power of Tailwind CSS, including media queries, container queries, and custom values, while still having the performance of a native style system.
 

--- a/apps/website/versioned_docs/version-v2/home.md
+++ b/apps/website/versioned_docs/version-v2/home.md
@@ -10,7 +10,7 @@ custom_edit_url: null
 
 NativeWind uses [Tailwind CSS](https://tailwindcss.com) as scripting language to create a **universal style system** for React Native. NativeWind components can be shared between platforms and will output their styles as CSS StyleSheet on web and StyleSheet.create for native.
 
-It's goals are to to provide a consistent styling experience across all platforms, improve Developer UX and code maintainability.
+Its goals are to to provide a consistent styling experience across all platforms, improve Developer UX and code maintainability.
 
 NativeWind achieves this by pre-compiling your styles and uses a minimal runtime to selectively apply responsive styles.
 

--- a/apps/website/versioned_docs/version-v2/overview/overview.md
+++ b/apps/website/versioned_docs/version-v2/overview/overview.md
@@ -2,7 +2,7 @@
 
 ## What is NativeWind?
 
-NativeWind uses [Tailwind CSS](https://tailwindcss.com) as scripting language to create a **universal styling system**. Styled components can be shared between all React Native platforms, using the best style engine for that platform; CSS StyleSheet on web and StyleSheet.create for native. It's goals are to provide a consistent styling experience across all platforms, improving Developer UX, component performance and code maintainability.
+NativeWind uses [Tailwind CSS](https://tailwindcss.com) as scripting language to create a **universal styling system**. Styled components can be shared between all React Native platforms, using the best style engine for that platform; CSS StyleSheet on web and StyleSheet.create for native. Its goals are to provide a consistent styling experience across all platforms, improving Developer UX, component performance and code maintainability.
 
 NativeWind processes your styles during your application's build and uses a minimal runtime to selectively apply responsive styles (eg changes to device orientation, color scheme).
 

--- a/packages/nativewind/README.md
+++ b/packages/nativewind/README.md
@@ -18,7 +18,7 @@
 >
 > NativeWind is still under development
 
-`NativeWind` uses [Tailwind CSS](https://tailwindcss.com) as high-level scripting language to create a **universal design system**. Styled components can be shared between all React Native platforms, using the best style engine for that platform (e.g. CSS StyleSheet or StyleSheet.create). It's goals are to to provide a consistent styling experience across all platforms, improving Developer UX, component performance and code maintainability.
+`NativeWind` uses [Tailwind CSS](https://tailwindcss.com) as high-level scripting language to create a **universal design system**. Styled components can be shared between all React Native platforms, using the best style engine for that platform (e.g. CSS StyleSheet or StyleSheet.create). Its goals are to to provide a consistent styling experience across all platforms, improving Developer UX, component performance and code maintainability.
 
 `NativeWind` processes your styles during your application build, and uses a minimal runtime to selectively apply reactive styles (eg changes to device orientation, light dark mode).
 


### PR DESCRIPTION
The phrase "**it's goals**" has been used throughout the project. I'm aware that this is slightly pedantic of me, but this is a grammatical mistake, it should be "**its goals**", [as per the Cambridge Dictionary](https://dictionary.cambridge.org/grammar/british-grammar/it-s-or-its).