### PR TITLE
typo fix for tailwind.config.js file

### DIFF
--- a/apps/website/docs/tailwind/backgrounds/background-color.mdx
+++ b/apps/website/docs/tailwind/backgrounds/background-color.mdx
@@ -17,7 +17,7 @@ If you need to use this feature, you can enable it by adding the following to yo
 ```js title=tailwind.config.js
 module.exports = {
   /* ...  */
-  corePlugin: {
+  corePlugins: {
     backgroundOpacity: true,
   },
 };


### PR DESCRIPTION
The config key was incorrect, i.e., it was corePlugin instead of corePlugins