### PR TITLE
fix: setColorScheme and toggleColorScheme

### DIFF
--- a/packages/nativewind/src/__tests__/dark-mode.tsx
+++ b/packages/nativewind/src/__tests__/dark-mode.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource nativewind */
-import { View } from "react-native";
-import { colorScheme, render } from "../test-utils";
-import { act, screen } from "@testing-library/react-native";
+import { View, Text, Button } from "react-native";
+import { colorScheme, render, useColorScheme } from "../test-utils";
+import { act, screen, within } from "@testing-library/react-native";
 
 const testID = "react-native-css-interop";
 
@@ -128,4 +128,97 @@ test("darkMode: class variable switching", async () => {
   act(() => colorScheme.set("dark"));
 
   expect(component).toHaveStyle({ color: "rgb(155, 100, 255)" });
+});
+
+test("useColorScheme().setColorScheme() with darkMode: class", async () => {
+  const testIds = {
+    TEXT: "useColorScheme",
+    DARK_BUTTON: "dark_button",
+    LIGHT_BUTTON: "light_button",
+    SYSTEM_BUTTON: "system_button",
+  };
+
+  function UseColorScheme() {
+    const { colorScheme, setColorScheme } = useColorScheme();
+
+    return (
+      <View>
+        <Text testID={testIds.TEXT}>{colorScheme}</Text>
+        <Button
+          testID={testIds.DARK_BUTTON}
+          title="Dark"
+          onPress={() => setColorScheme("dark")}
+        />
+        <Button
+          testID={testIds.LIGHT_BUTTON}
+          title="Light"
+          onPress={() => setColorScheme("light")}
+        />
+        <Button
+          testID={testIds.SYSTEM_BUTTON}
+          title="System"
+          onPress={() => setColorScheme("system")}
+        />
+      </View>
+    );
+  }
+  await render(<UseColorScheme />, {
+    config: {
+      darkMode: "class",
+    },
+  });
+
+  const { getByText } = within(screen.getByTestId(testIds.TEXT));
+
+  // Should render light by default
+  expect(getByText("light")).toBeTruthy();
+
+  // Press the dark button
+  act(() => screen.getByTestId(testIds.DARK_BUTTON).props.onClick());
+  expect(getByText("dark")).toBeTruthy();
+
+  // Press the light button
+  act(() => screen.getByTestId(testIds.LIGHT_BUTTON).props.onClick());
+  expect(getByText("light")).toBeTruthy();
+
+  // Press the system button
+  act(() => screen.getByTestId(testIds.SYSTEM_BUTTON).props.onClick());
+  expect(getByText("light")).toBeTruthy();
+});
+
+test("useColorScheme().toggleColorScheme() with darkMode: class", async () => {
+  const testIds = {
+    TEXT: "useColorScheme",
+    TOGGLE_BUTTON: "toggle_button",
+  };
+
+  function UseColorScheme() {
+    const { colorScheme, toggleColorScheme } = useColorScheme();
+
+    return (
+      <View>
+        <Text testID={testIds.TEXT}>{colorScheme}</Text>
+        <Button
+          testID={testIds.TOGGLE_BUTTON}
+          title="toggle"
+          onPress={toggleColorScheme}
+        />
+      </View>
+    );
+  }
+  await render(<UseColorScheme />, {
+    config: {
+      darkMode: "class",
+    },
+  });
+
+  const { getByText } = within(screen.getByTestId(testIds.TEXT));
+
+  expect(getByText("light")).toBeTruthy();
+  act(() => screen.getByTestId(testIds.TOGGLE_BUTTON).props.onClick());
+  expect(getByText("dark")).toBeTruthy();
+  act(() => screen.getByTestId(testIds.TOGGLE_BUTTON).props.onClick());
+  expect(getByText("light")).toBeTruthy();
+  act(() => screen.getByTestId(testIds.TOGGLE_BUTTON).props.onClick());
+  expect(getByText("dark")).toBeTruthy();
 });

--- a/packages/nativewind/src/stylesheet.ts
+++ b/packages/nativewind/src/stylesheet.ts
@@ -8,21 +8,25 @@ export function useColorScheme() {
   return {
     ...colorScheme,
     setColorScheme(scheme: Parameters<typeof colorScheme.setColorScheme>[0]) {
-      const darkMode = StyleSheet.getFlag("darkMode") ?? "media";
-      if (darkMode === "media") {
-        throw new Error(
-          "Unable to manually set color scheme without using darkMode: class. See: https://tailwindcss.com/docs/dark-mode#toggling-dark-mode-manually",
-        );
+      if ("getFlag" in StyleSheet) {
+        const darkMode = StyleSheet.getFlag("darkMode") ?? "media";
+        if (darkMode === "media") {
+          throw new Error(
+            "Unable to manually set color scheme without using darkMode: class. See: https://tailwindcss.com/docs/dark-mode#toggling-dark-mode-manually",
+          );
+        }
       }
 
       colorScheme?.setColorScheme(scheme);
     },
     toggleColorScheme() {
-      const darkMode = StyleSheet.getFlag("darkMode") ?? "media";
-      if (darkMode === "media") {
-        throw new Error(
-          "Unable to manually set color scheme without using darkMode: class. See: https://tailwindcss.com/docs/dark-mode#toggling-dark-mode-manually",
-        );
+      if ("getFlag" in StyleSheet) {
+        const darkMode = StyleSheet.getFlag("darkMode") ?? "media";
+        if (darkMode === "media") {
+          throw new Error(
+            "Unable to manually set color scheme without using darkMode: class. See: https://tailwindcss.com/docs/dark-mode#toggling-dark-mode-manually",
+          );
+        }
       }
 
       colorScheme?.toggleColorScheme();


### PR DESCRIPTION
Just a preliminary fix for the `setColorScheme` / `toggleColorScheme` functions used in native. I'm not too familiar with the StyleSheet typings, but I suspect the `runtime/web/stylesheet.ts` object isn't supposed to be loaded on native?

Anyways, before the fix: 
<img src="https://github.com/user-attachments/assets/dfb1cc8a-bf69-4b2c-8aa1-0734a9a175cd" width="400" />

Repro in the test suite before fixing: (didn't wrap in `act(() => ...)` though)
![image](https://github.com/user-attachments/assets/f526d322-49ec-496a-8041-8fd1ee681ba7)
