### PR TITLE
Detect nativewind/preset recursively

### DIFF
--- a/.changeset/rich-hairs-lie.md
+++ b/.changeset/rich-hairs-lie.md
@@ -1,0 +1,5 @@
+---
+"nativewind": patch
+---
+
+fix issue where Nativewind preset is not detected when deeply nested in Tailwind configuration

--- a/packages/nativewind/src/metro/tailwind/v3/index.ts
+++ b/packages/nativewind/src/metro/tailwind/v3/index.ts
@@ -1,6 +1,7 @@
 import { execSync, fork } from "child_process";
 import fs from "fs";
 import path from "path";
+import { type Config } from 'tailwindcss';
 import { TailwindCliOptions } from "../types";
 
 /**
@@ -90,10 +91,18 @@ export const tailwindCliV3 = {
   },
 };
 
-export function tailwindConfigV3(path: string) {
-  const config = require("tailwindcss/loadConfig")(path);
+const flattenPresets = (configs: Partial<Config>[] = []): Partial<Config>[] => {
+  if (!configs) return [];
+  return configs.flatMap(config => [
+    config,
+    ...flattenPresets(config.presets)
+  ]);
+};
 
-  const hasPreset = config.presets?.some((preset: any) => {
+export function tailwindConfigV3(path: string) {
+  const config: Config = require("tailwindcss/loadConfig")(path);
+
+  const hasPreset = flattenPresets(config.presets).some((preset) => {
     return preset.nativewind;
   });
 


### PR DESCRIPTION
This check was introduced in version 4.1 and now incorrectly throws an error even though 'nativewind/preset' is present in the resolved configuration.

This PR resolves the issue by flattening the presets to detect nativewind preset under nested configuration.