### PR TITLE
allow dot notation for cssInterop config targetting

### DIFF
--- a/.changeset/angry-swans-ring.md
+++ b/.changeset/angry-swans-ring.md
@@ -1,0 +1,6 @@
+---
+"react-native-css-interop": patch
+"nativewind": patch
+---
+
+allow dot notation for cssInterop config targetting

--- a/packages/react-native-css-interop/src/__tests__/custom-components.test.tsx
+++ b/packages/react-native-css-interop/src/__tests__/custom-components.test.tsx
@@ -1,4 +1,5 @@
-import { TextInput } from "react-native";
+import { FunctionComponent } from "react";
+import { TextInput, View } from "react-native";
 import { screen, cssInterop, registerCSS, render } from "test";
 
 const testID = "react-native-css-interop";
@@ -43,6 +44,44 @@ it("can create custom components", () => {
     textAlign: "center",
     style: {
       color: "rgba(255, 0, 0, 1)",
+    },
+  });
+});
+
+it("can target deeply nested props", () => {
+  registerCSS(`
+    .a {
+      color: red;
+      background-color: blue;
+    }
+  `);
+
+  const MyComp: FunctionComponent<{
+    testID?: string;
+    deeply?: { nested: { target: any; backgroundColor: string } };
+  }> = jest.fn((props) => <View {...props} />);
+
+  const MyStyledComp = cssInterop(MyComp, {
+    className: {
+      target: "deeply.nested.target",
+      nativeStyleToProp: {
+        backgroundColor: "deeply.nested.backgroundColor",
+      },
+    },
+  });
+
+  render(<MyStyledComp testID={testID} className="a" />);
+
+  expect(screen.getByTestId(testID).props).toStrictEqual({
+    testID,
+    children: undefined,
+    deeply: {
+      nested: {
+        backgroundColor: "rgba(0, 0, 255, 1)",
+        target: {
+          color: "rgba(255, 0, 0, 1)",
+        },
+      },
     },
   });
 });

--- a/packages/react-native-css-interop/src/__tests__/custom-components.test.tsx
+++ b/packages/react-native-css-interop/src/__tests__/custom-components.test.tsx
@@ -85,3 +85,88 @@ it("can target deeply nested props", () => {
     },
   });
 });
+
+it("works with @rn-move", () => {
+  registerCSS(`
+    .a {
+      @rn-move color myColor;
+      color: red;
+      font-size: 14px;
+      background-color: blue;
+    }
+  `);
+
+  const MyComp: FunctionComponent<{
+    testID?: string;
+    deeply?: { nested: { target: any; backgroundColor: string } };
+  }> = jest.fn((props) => <View {...props} />);
+
+  const MyStyledComp = cssInterop(MyComp, {
+    className: {
+      target: "deeply.nested.target",
+      nativeStyleToProp: {
+        backgroundColor: "deeply.nested.backgroundColor",
+      },
+    },
+  });
+
+  render(<MyStyledComp testID={testID} className="a" />);
+
+  expect(screen.getByTestId(testID).props).toStrictEqual({
+    testID,
+    children: undefined,
+    deeply: {
+      nested: {
+        backgroundColor: "rgba(0, 0, 255, 1)",
+        myColor: "rgba(255, 0, 0, 1)",
+        target: {
+          fontSize: 14,
+        },
+      },
+    },
+  });
+});
+
+it("works with @rn-move and nativeStyleToProps", () => {
+  registerCSS(`
+    .a {
+      @rn-move color myColor;
+      color: red;
+      font-size: 14px;
+      background-color: blue;
+    }
+  `);
+
+  const MyComp: FunctionComponent<{
+    testID?: string;
+    deeply?: {
+      nested: { target: any; backgroundColor: string };
+      color?: string;
+    };
+  }> = jest.fn((props) => <View {...props} />);
+
+  const MyStyledComp = cssInterop(MyComp, {
+    className: {
+      target: "deeply.nested.target",
+      nativeStyleToProp: {
+        color: "deeply.color",
+      },
+    },
+  });
+
+  render(<MyStyledComp testID={testID} className="a" />);
+
+  expect(screen.getByTestId(testID).props).toStrictEqual({
+    testID,
+    children: undefined,
+    deeply: {
+      color: "rgba(255, 0, 0, 1)",
+      nested: {
+        target: {
+          backgroundColor: "rgba(0, 0, 255, 1)",
+          fontSize: 14,
+        },
+      },
+    },
+  });
+});

--- a/packages/react-native-css-interop/src/__tests__/refs.test.tsx
+++ b/packages/react-native-css-interop/src/__tests__/refs.test.tsx
@@ -10,8 +10,9 @@ import { ViewProps } from "react-native";
 import { render, createMockComponent, registerCSS } from "test";
 
 const testID = "react-native-css-interop";
+const mapping = { className: "style" } as const;
 
-const FunctionComponent = createMockComponent<any>((props: ViewProps) => null);
+const FunctionComponent = createMockComponent((_: ViewProps) => null, mapping);
 
 const ForwardRef = createMockComponent(
   forwardRef((props: ViewProps, ref: any) => {
@@ -21,10 +22,11 @@ const ForwardRef = createMockComponent(
 
     return null;
   }),
+  mapping,
 );
 
 const ClassComponent = createMockComponent(
-  class MyComponent extends PureComponent<any> {
+  class MyComponent extends PureComponent<ViewProps> {
     getProps = () => {
       return this.props;
     };
@@ -32,12 +34,14 @@ const ClassComponent = createMockComponent(
       return null;
     }
   },
+  mapping,
 );
 
 const ChildComponent = createMockComponent(
   forwardRef((props: ViewProps, ref: any) => {
     return <ClassComponent ref={ref} {...props} />;
   }),
+  mapping,
 );
 
 test("FunctionComponent", () => {
@@ -48,7 +52,9 @@ test("FunctionComponent", () => {
   const mockError = jest.fn();
   console.error = mockError;
 
-  render(<FunctionComponent ref={ref} testID={testID} className="my-class" />);
+  render(
+    <FunctionComponent ref={ref as any} testID={testID} className="my-class" />,
+  );
 
   expect(mockError.mock.lastCall?.[0]).toMatch(
     /Warning: Function components cannot be given refs\. Attempts to access this ref will fail\. Did you mean to use React\.forwardRef()?/,

--- a/packages/react-native-css-interop/src/runtime/config.ts
+++ b/packages/react-native-css-interop/src/runtime/config.ts
@@ -1,48 +1,58 @@
-import {
-  EnableCssInteropOptions,
-  InteropComponentConfig,
-  NativeStyleToProp,
-} from "../types";
+import { EnableCssInteropOptions, InteropComponentConfig } from "../types";
 
 export function getNormalizeConfig(
   mapping: EnableCssInteropOptions<any>,
 ): InteropComponentConfig[] {
-  const config = new Map<string, InteropComponentConfig>();
+  const configs: InteropComponentConfig[] = [];
 
-  for (const [source, options] of Object.entries(mapping) as Array<
-    [string, EnableCssInteropOptions<any>[string]]
-  >) {
-    let target: string;
-    let nativeStyleToProp: NativeStyleToProp<any> | undefined;
-    let removeTarget: true | undefined;
+  for (const [source, options] of Object.entries(mapping)) {
+    let target: string[];
+    let inlineProp: string | undefined;
+    let propToRemove: string | undefined;
+    let nativeStyleToProp: InteropComponentConfig["nativeStyleToProp"];
 
     if (!options) continue;
 
-    if (typeof options === "boolean") {
-      target = source;
+    if (options === true) {
+      target = [source];
     } else if (typeof options === "string") {
-      target = options;
+      target = [options];
     } else if (options.target === false) {
       /*
        * Even when target == false, you still need to process as normal. As nativeStyleToProp may move a style
        * Once the styles are moved, you then need to remove the prop as there maybe left over styles
        * e.g paddingTop: calc(10 + 2em). The user may also set a fontSize here to force a value of the `em`
        */
-      target = source;
-      nativeStyleToProp = options.nativeStyleToProp;
-      removeTarget = true;
+      target = [source];
+      propToRemove = source;
+      nativeStyleToProp = parseNativeStyleToProp(options.nativeStyleToProp);
     } else {
-      target = options.target === true ? source : options.target;
-      nativeStyleToProp = options.nativeStyleToProp;
+      target = options.target === true ? [source] : options.target.split(".");
+      nativeStyleToProp = parseNativeStyleToProp(options.nativeStyleToProp);
     }
 
-    config.set(target, {
+    if (target.length === 1 && target[0] !== source) {
+      inlineProp = target[0];
+    }
+
+    configs.push({
       nativeStyleToProp,
       source,
       target,
-      removeTarget,
+      inlineProp,
+      propToRemove,
     });
   }
 
-  return Array.from(config.values());
+  return configs;
+}
+
+function parseNativeStyleToProp(
+  nativeStyleToProp?: Record<string, string | true>,
+): InteropComponentConfig["nativeStyleToProp"] {
+  if (!nativeStyleToProp) return;
+
+  return Object.entries(nativeStyleToProp).map(([key, value]) => {
+    return [key, value === true ? [key] : value.split(".")];
+  });
 }

--- a/packages/react-native-css-interop/src/runtime/native/api.ts
+++ b/packages/react-native-css-interop/src/runtime/native/api.ts
@@ -10,6 +10,7 @@ import { interop } from "./native-interop";
 import { getComponentType } from "./unwrap-components";
 import { VariableContext, getVariable, opaqueStyles } from "./styles";
 import { colorScheme } from "./appearance-observables";
+import { assignToTarget } from "./utils";
 
 export { StyleSheet } from "./stylesheet";
 export { colorScheme } from "./appearance-observables";
@@ -75,17 +76,9 @@ export const remapProps: CssInterop = (component: any, mapping): any => {
 
       delete props[config.source];
 
-      let target = props[config.target];
-
-      if (Array.isArray(target)) {
-        target.push(placeholder);
-      } else if (target) {
-        target = [target, placeholder];
-      } else {
-        target = placeholder;
-      }
-
-      props[config.target] = target;
+      assignToTarget(props, placeholder, config, {
+        objectMergeStyle: "toArray",
+      });
     }
 
     props.ref = ref;

--- a/packages/react-native-css-interop/src/runtime/native/native-interop.ts
+++ b/packages/react-native-css-interop/src/runtime/native/native-interop.ts
@@ -904,17 +904,29 @@ function applyRules(
       if (declaration.length === 2) {
         const paths =
           declaration[0] === "style"
-            ? [...target, ...declaration.slice(1)]
-            : [...target.slice(0, -1), ...declaration[1]];
+            ? target
+            : [...target.slice(0, -1), ...declaration[0]];
 
         assignToTarget(props, declaration[1], paths);
       } else {
-        // The styles say they are "style", but they should go to the first target
-        // If they don't say "style" then they have a @rn-move rule that has already moved them
-        const paths =
+        const isNativeStyleToProp = state.config.nativeStyleToProp?.some(
+          (value) => value[0] === declaration[0],
+        );
+
+        let paths: string[];
+
+        if (isNativeStyleToProp) {
+          paths = [...target, declaration[0]];
+        } else if (
+          declaration[1].length === 1 &&
           declaration[1][0] === "style"
-            ? [...target, ...declaration[1].slice(1)]
-            : [...target.slice(0, -1), ...declaration[1]];
+        ) {
+          // The styles say they are "style", but they should go to the first target
+          // If they don't say "style" then they have a @rn-move rule that has already moved them
+          paths = [...target, ...declaration[1]];
+        } else {
+          paths = [...target.slice(0, -1), ...declaration[1]];
+        }
 
         // em / rnw / rnh units use other declarations, so we need to delay them
         if (typeof declaration[2] === "object" && declaration[2].delay) {

--- a/packages/react-native-css-interop/src/runtime/native/native-interop.ts
+++ b/packages/react-native-css-interop/src/runtime/native/native-interop.ts
@@ -47,6 +47,7 @@ import {
   getStyle,
 } from "./styles";
 import { DEFAULT_CONTAINER_NAME } from "../../shared";
+import { assignToTarget, getTargetValue } from "./utils";
 
 export function interop(
   component: ReactComponent<any>,
@@ -365,7 +366,7 @@ function getDeclarations(
     containerNames: undefined,
     variables: undefined,
     // Reset the inline styles
-    inline: refs.props?.[config.target],
+    inline: getTargetValue(refs.props, config),
     // Keep the same effect, but reset the guards
     declarationTracking: {
       effect: previousState.declarationTracking.effect,
@@ -381,7 +382,7 @@ function getDeclarations(
   state.declarationTracking.guards.push(
     (refs) =>
       !Object.is(refs.props?.[config.source], state.className) ||
-      !Object.is(refs.props?.[config.target], state.inline),
+      !Object.is(getTargetValue(refs.props, config), state.inline),
   );
 
   const normalRules: ProcessedStyleRules[] = [];
@@ -401,11 +402,11 @@ function getDeclarations(
     }
   }
 
-  if (config.source !== config.target && refs.props?.[config.target]) {
+  if (config.inlineProp && refs.props?.[config.inlineProp]) {
     collectInlineRules(
       state,
       refs,
-      refs.props[config.target],
+      refs.props[config.inlineProp],
       state.declarationTracking.effect,
       normalRules,
       importantRules,
@@ -651,7 +652,9 @@ function processAnimations(
             iterationCount.type === "infinite" ? -1 : iterationCount.value,
           );
 
-          setDeep(props, pathTokens, sharedValue);
+          assignToTarget(props, sharedValue, pathTokens, {
+            allowTransformMerging: true,
+          });
         }
       }
     } else {
@@ -659,10 +662,15 @@ function processAnimations(
         const keyframes = getAnimation(name, state.styleTracking.effect);
         if (!keyframes) continue;
 
-        props[state.config.target] ??= {};
-
         for (const [animationKey, { pathTokens }] of keyframes.frames) {
-          setDeep(props, pathTokens, state.sharedValues.get(animationKey));
+          assignToTarget(
+            props,
+            state.sharedValues.get(animationKey),
+            pathTokens,
+            {
+              allowTransformMerging: true,
+            },
+          );
           seenAnimatedProps.add(animationKey);
         }
       }
@@ -773,7 +781,9 @@ function processTransition(
 
       seenAnimatedProps.add(property);
       props.style ??= {};
-      setDeep(props.style, [property], sharedValue);
+      assignToTarget(props.style, sharedValue, [property], {
+        allowTransformMerging: true,
+      });
     }
   }
 }
@@ -800,7 +810,9 @@ function retainSharedValues(
     props.style?.[entry[0]] ??
       state.styleLookup[entry[0]] ??
       defaultValues[entry[0]];
-    setDeep(props.style, [entry[0]], entry[1]);
+    assignToTarget(props.style, entry[1], [entry[0]], {
+      allowTransformMerging: true,
+    });
   }
 }
 
@@ -844,17 +856,21 @@ function handleUpgrades(sharedState: SharedState, ruleSet: StyleRuleSet) {
 function cleanup(props: Record<string, any>, config: InteropComponentConfig) {
   if (!config.nativeStyleToProp) return;
 
-  for (let move of Object.entries(config.nativeStyleToProp)) {
+  for (let move of config.nativeStyleToProp) {
     const source = move[0];
-    const sourceValue = props[config.target]?.[source];
-    if (sourceValue === undefined) continue;
-    const targetProp = move[1] === true ? move[0] : move[1];
-    props[targetProp] = sourceValue;
-    delete props[config.target][source];
+
+    const target = getTargetValue(props, config);
+
+    if (!target || !(source in target)) continue;
+
+    assignToTarget(props, target[source], move[1], {
+      allowTransformMerging: true,
+    });
+    delete target[source];
   }
 
-  if (config.removeTarget) {
-    delete props[config.target];
+  if (config.propToRemove) {
+    delete props[config.propToRemove];
   }
 }
 
@@ -886,19 +902,19 @@ function applyRules(
   for (const declaration of declarations) {
     if (Array.isArray(declaration)) {
       if (declaration.length === 2) {
-        const prop = declaration[0] === "style" ? target : declaration[0];
-        if (typeof declaration[1] === "object") {
-          props[prop] ??= {};
-          Object.assign(props[prop], declaration[1]);
-        } else {
-          props[prop] = declaration[1];
-        }
-      } else {
-        const paths = [...declaration[1]];
+        const paths =
+          declaration[0] === "style"
+            ? [...target, ...declaration.slice(1)]
+            : [...target.slice(0, -1), ...declaration[1]];
 
-        if (target !== "style" && paths[0] === "style") {
-          paths[0] = target;
-        }
+        assignToTarget(props, declaration[1], paths);
+      } else {
+        // The styles say they are "style", but they should go to the first target
+        // If they don't say "style" then they have a @rn-move rule that has already moved them
+        const paths =
+          declaration[1][0] === "style"
+            ? [...target, ...declaration[1].slice(1)]
+            : [...target.slice(0, -1), ...declaration[1]];
 
         // em / rnw / rnh units use other declarations, so we need to delay them
         if (typeof declaration[2] === "object" && declaration[2].delay) {
@@ -912,9 +928,11 @@ function applyRules(
               refs,
               state.styleTracking,
               declaration[2],
-              props[target],
+              getTargetValue(props, state.config),
             );
-            setDeep(props, paths, value);
+            assignToTarget(props, value, paths, {
+              allowTransformMerging: true,
+            });
             lookup[declaration[0]] = value;
           });
         } else {
@@ -923,19 +941,19 @@ function applyRules(
             refs,
             state.styleTracking,
             declaration[2],
-            props[target],
+            getTargetValue(props, state.config),
           );
-          setDeep(props, paths, value);
+          assignToTarget(props, value, paths, {
+            allowTransformMerging: true,
+          });
           lookup[declaration[0]] = value;
         }
       }
     } else {
-      if (typeof props[target] === "object") {
-        Object.assign(props[target], declaration);
-      } else {
-        // Make sure we clone this, as it may be a frozen style object
-        props[target] = { ...declaration };
-      }
+      // Make sure we clone this, as it may be a frozen style object
+      assignToTarget(props, { ...declaration }, state.config, {
+        objectMergeStyle: "assign",
+      });
     }
   }
 }
@@ -969,24 +987,6 @@ function specificityCompare(
     return 0; /* Appearance Order */
   }
 }
-
-const transformKeys = new Set([
-  "transform",
-  "translateX",
-  "translateY",
-  "scale",
-  "scaleX",
-  "scaleY",
-  "rotate",
-  "rotateX",
-  "rotateY",
-  "rotateZ",
-  "skewX",
-  "skewY",
-  "perspective",
-  "matrix",
-  "transformOrigin",
-]);
 
 function collectRules(
   state: ReducerState,
@@ -1081,32 +1081,6 @@ const defaultTransition: Required<ExtractedTransition> = {
   delay: [{ type: "seconds", value: 0 }],
   timingFunction: [{ type: "linear" }],
 };
-
-function setDeep(target: Record<string, any>, paths: string[], value: any) {
-  const prop = paths[paths.length - 1];
-  for (let i = 0; i < paths.length - 1; i++) {
-    const token = paths[i];
-    target[token] ??= {};
-    target = target[token];
-  }
-  if (transformKeys.has(prop)) {
-    if (target.transform) {
-      const existing = target.transform.find(
-        (t: any) => Object.keys(t)[0] === prop,
-      );
-      if (existing) {
-        existing[prop] = value;
-      } else {
-        target.transform.push({ [prop]: value });
-      }
-    } else {
-      target.transform ??= [];
-      target.transform.push({ [prop]: value });
-    }
-  } else {
-    target[prop] = value;
-  }
-}
 
 /**
  * Perform a DeepEqual comparison that cares about order

--- a/packages/react-native-css-interop/src/runtime/native/resolve-value.ts
+++ b/packages/react-native-css-interop/src/runtime/native/resolve-value.ts
@@ -9,6 +9,7 @@ import { ReducerState, ReducerTracking, Refs } from "./types";
 import { getUniversalVariable, getVariable } from "./styles";
 import { systemColorScheme } from "./appearance-observables";
 import { rem, vh, vw } from "./unit-observables";
+import { getTargetValue } from "./utils";
 
 /**
  * Get the final value of a value descriptor
@@ -442,7 +443,7 @@ export function resolveTransitionValue(state: ReducerState, property: string) {
     defaultValue,
     value:
       state.styleLookup[property] ??
-      state.props?.[state.config.target]?.[property],
+      getTargetValue(state.props, state.config)?.[property],
   };
 }
 

--- a/packages/react-native-css-interop/src/runtime/native/utils.ts
+++ b/packages/react-native-css-interop/src/runtime/native/utils.ts
@@ -1,0 +1,110 @@
+import { InteropComponentConfig } from "../../types";
+
+type ArrayMergeStyles = "push";
+type ObjectMergeStyles = "assign" | "toArray";
+
+export function getTargetValue(
+  target: Record<string, any> | undefined | null,
+  config: InteropComponentConfig,
+) {
+  for (let index = 0; index < config.target.length && target; index++) {
+    const prop = config.target[index];
+    target = target[prop];
+  }
+
+  return target || undefined;
+}
+
+export function assignToTarget(
+  parent: Record<string, any>,
+  value: any,
+  config: InteropComponentConfig | string[],
+  {
+    arrayMergeStyle = "push",
+    objectMergeStyle = "assign",
+    allowTransformMerging = false,
+  }: {
+    arrayMergeStyle?: ArrayMergeStyles;
+    objectMergeStyle?: ObjectMergeStyles;
+    allowTransformMerging?: boolean;
+  } = {},
+) {
+  let prop: string | number;
+
+  const props = Array.isArray(config) ? config : config.target;
+
+  for (let index = 0; index < props.length - 1; index++) {
+    prop = props[index];
+
+    if (Array.isArray(parent) && isFinite(Number(prop))) {
+      prop = Number(prop);
+    }
+
+    if (typeof parent[prop] !== "object") {
+      parent[prop] = {};
+    }
+
+    parent = parent[prop];
+  }
+
+  // Now use the last value
+  prop = props[props.length - 1];
+
+  if (allowTransformMerging && transformKeys.has(prop)) {
+    let existing;
+    if (!Array.isArray(parent.transform)) {
+      parent.transform = [];
+    } else {
+      existing = parent.transform.find((t: object) => prop in t);
+    }
+
+    if (existing) {
+      existing[prop] = value;
+    } else {
+      parent.transform.push({ [prop]: value });
+    }
+  } else {
+    const target = parent[prop];
+
+    if (Array.isArray(target)) {
+      switch (arrayMergeStyle) {
+        case "push":
+          target.push(value);
+      }
+    } else if (typeof target === "object" && target) {
+      switch (objectMergeStyle) {
+        case "assign": {
+          if (typeof value === "object") {
+            parent[prop] = Object.assign({}, parent[prop], value);
+          } else {
+            parent[prop] = value;
+          }
+          break;
+        }
+        case "toArray": {
+          parent[prop] = [target, value];
+        }
+      }
+    } else {
+      parent[prop] = value;
+    }
+  }
+}
+
+const transformKeys = new Set([
+  "transform",
+  "translateX",
+  "translateY",
+  "scale",
+  "scaleX",
+  "scaleY",
+  "rotate",
+  "rotateX",
+  "rotateY",
+  "rotateZ",
+  "skewX",
+  "skewY",
+  "perspective",
+  "matrix",
+  "transformOrigin",
+]);

--- a/packages/react-native-css-interop/src/runtime/web/api.ts
+++ b/packages/react-native-css-interop/src/runtime/web/api.ts
@@ -1,8 +1,9 @@
 import { Component, createElement, forwardRef, useState } from "react";
-import { CssInterop, StyleProp, JSXFunction } from "../../types";
+import { CssInterop, JSXFunction } from "../../types";
 import { getNormalizeConfig } from "../config";
 import { Effect } from "../observable";
 import { colorScheme } from "./color-scheme";
+import { assignToTarget } from "../native/utils";
 
 export { StyleSheet } from "./stylesheet";
 export { colorScheme } from "./color-scheme";
@@ -34,29 +35,24 @@ export const cssInterop: CssInterop = (baseComponent, mapping): any => {
 
     props = { ...props, ref };
     for (const config of configs) {
-      let newStyles: StyleProp = [];
       const source = props[config.source];
-      const target: StyleProp = props[config.target];
 
       // Ensure we only add non-empty strings
       if (typeof source === "string" && source) {
-        newStyles.push({
-          $$css: true,
-          [source]: source,
-        } as StyleProp);
+        assignToTarget(
+          props,
+          {
+            $$css: true,
+            [source]: source,
+          },
+          config,
+          {
+            objectMergeStyle: "toArray",
+          },
+        );
       }
 
       delete props[config.source];
-
-      if (Array.isArray(target)) {
-        newStyles.push(...target);
-      } else if (target) {
-        newStyles.push(target);
-      }
-
-      if (newStyles.length > 0) {
-        props[config.target] = newStyles;
-      }
     }
 
     if (

--- a/packages/react-native-css-interop/src/utils/test/index.tsx
+++ b/packages/react-native-css-interop/src/utils/test/index.tsx
@@ -1,4 +1,10 @@
-import { ComponentProps, ComponentType, ReactElement, forwardRef } from "react";
+import {
+  ComponentProps,
+  ComponentRef,
+  ForwardedRef,
+  ReactElement,
+  forwardRef,
+} from "react";
 import {
   render as tlRender,
   RenderOptions as TLRenderOptions,
@@ -15,7 +21,6 @@ import {
   EnableCssInteropOptions,
   ReactComponent,
   Style,
-  CssInteropGeneratedProps,
 } from "../../types";
 import { isReduceMotionEnabled } from "../../runtime/native/appearance-observables";
 import { resetData } from "../../runtime/native/styles";
@@ -87,53 +92,39 @@ export function getWarnings() {
  * Creates a mocked component that renders with the defaultCSSInterop WITHOUT needing
  * set the jsxImportSource.
  */
-export const createMockComponent = <
-  const T extends ReactComponent<any>,
-  const M extends EnableCssInteropOptions<any> = {
-    className: "style";
-  },
->(
-  Component: T,
-  mapping: M = {
-    className: "style",
-  } as unknown as M,
-) => {
+export function createMockComponent<
+  const C extends ReactComponent<any>,
+  const M extends EnableCssInteropOptions<C>,
+>(Component: C, mapping: M & EnableCssInteropOptions<C>) {
   cssInterop(Component, mapping);
 
-  const mock = jest.fn(({ ...props }, ref) => {
-    return createInteropElement(Component, { ...props, ref });
-  });
+  const mock = jest.fn(
+    ({ ...props }: ComponentProps<C>, ref: ForwardedRef<ComponentRef<C>>) => {
+      return createInteropElement(Component, { ...props, ref });
+    },
+  );
 
-  return Object.assign(forwardRef(mock as any), {
+  return Object.assign(forwardRef(mock), {
     mock,
-  }) as unknown as ComponentType<
-    ComponentProps<T> & CssInteropGeneratedProps<M>
-  > & { mock: typeof mock };
-};
+  });
+}
 
-export const createRemappedComponent = <
-  const T extends ReactComponent<any>,
-  const M extends EnableCssInteropOptions<any> = {
-    className: "style";
-  },
->(
-  Component: T,
-  mapping: M = {
-    className: "style",
-  } as unknown as M,
-) => {
+export function createRemappedComponent<
+  const C extends ReactComponent<any>,
+  const M extends EnableCssInteropOptions<C>,
+>(Component: C, mapping: M & EnableCssInteropOptions<C>) {
   remapProps(Component, mapping);
 
-  const mock = jest.fn(({ ...props }, ref) => {
-    return createInteropElement(Component, { ...props, ref });
-  });
+  const mock = jest.fn(
+    ({ ...props }: ComponentProps<C>, ref: ForwardedRef<ComponentRef<C>>) => {
+      return createInteropElement(Component, { ...props, ref });
+    },
+  );
 
-  return Object.assign(forwardRef(mock as any), {
+  return Object.assign(forwardRef(mock), {
     mock,
-  }) as unknown as ComponentType<
-    ComponentProps<T> & CssInteropGeneratedProps<M>
-  > & { mock: typeof mock };
-};
+  });
+}
 
 export const resetComponents = () => {
   interopComponents.clear();


### PR DESCRIPTION
Allow dot notation for the `target` prop in cssInterop

```
cssInterop(BottomSheet.Navigator, {
  backgroundClassName: "screenOptions.backgroundStyle"
})
```