### PR TITLE
feat: added discord links to the website

### DIFF
--- a/apps/website/docusaurus.config.js
+++ b/apps/website/docusaurus.config.js
@@ -94,6 +94,11 @@ const config = {
         },
         items: [
           {
+            href: "https://discord.gg/ypNakAFQ65",
+            label: "Discord",
+            position: "right",
+          },
+          {
             href: "https://github.com/marklawlor/nativewind",
             label: "GitHub",
             position: "right",
@@ -110,6 +115,11 @@ const config = {
                 label: "GitHub",
                 href: "https://github.com/marklawlor/nativewind",
               },
+              {
+                label: "Discord",
+                href: "https://discord.gg/ypNakAFQ65",
+              },
+
             ],
           },
         ],


### PR DESCRIPTION
Hey, I noticed it's hard to find the Discord so I added a link to the Discord to the header and footer. Let me know what you think about this change.

![image](https://github.com/user-attachments/assets/2bb08225-2157-404a-97e0-e8deb7b5bcbc)
![image](https://github.com/user-attachments/assets/14b74fab-f0ac-4ab9-aec4-03ba0c29c3b5)

If you don't like that now there is so much text in the header we can also change the discord and github text to logos

