### PR TITLE
fixed Slot import

### DIFF
--- a/apps/website/docs/getting-started/expo-router.mdx
+++ b/apps/website/docs/getting-started/expo-router.mdx
@@ -87,7 +87,7 @@ module.exports = withNativeWind(config, { input: './global.css' })
 ### 5. Import your CSS file
 
 ```js title="app/_layout.js"
-import Slot from "expo-router/Slot";
+import {Slot} from "expo-router";
 
 // Import your global CSS file
 import "../global.css"


### PR DESCRIPTION
typescript was throwing error on how Slot wasn't exported from expo router in previous import in latest create-expo-app project