### PR TITLE
Allow transition to be specified in an optional style

### DIFF
--- a/.changeset/weak-mice-peel.md
+++ b/.changeset/weak-mice-peel.md
@@ -1,0 +1,6 @@
+---
+"react-native-css-interop": patch
+"nativewind": patch
+---
+
+allow `transition` to be only specified in an optional style

--- a/packages/react-native-css-interop/src/__tests__/debugging.test.tsx
+++ b/packages/react-native-css-interop/src/__tests__/debugging.test.tsx
@@ -8,11 +8,11 @@ setupAllComponents();
 describe("debugging", () => {
   const originalLog = console.log;
 
-  beforeAll(() => {
+  beforeEach(() => {
     console.log = jest.fn();
   });
 
-  afterAll(() => {
+  afterEach(() => {
     console.log = originalLog;
   });
 
@@ -143,6 +143,7 @@ describe("debugging", () => {
       color: "rgba(239, 68, 68, 1)",
     });
 
+    expect(console.log).toHaveBeenCalledTimes(1);
     expect(console.log)
       .toHaveBeenCalledWith(`Debugging component.testID 'debugClassName'
 
@@ -169,9 +170,9 @@ describe("debugging", () => {
   "variables": {},
   "containers": {
     "test": {
+      "initialRender": false,
       "originalProps": "[Circular]",
       "props": {},
-      "guardsEnabled": true,
       "canUpgradeWarn": false,
       "animated": 0,
       "containers": 1,

--- a/packages/react-native-css-interop/src/__tests__/grouping.test.tsx
+++ b/packages/react-native-css-interop/src/__tests__/grouping.test.tsx
@@ -1,5 +1,6 @@
 /** @jsxImportSource test */
 import { View } from "react-native";
+import { getAnimatedStyle } from "react-native-reanimated";
 
 import {
   fireEvent,
@@ -13,6 +14,8 @@ const grouping = ["^group(/.*)?"];
 const parentID = "parent";
 const childID = "child";
 setupAllComponents();
+
+jest.useFakeTimers();
 
 test("group", async () => {
   registerCSS(
@@ -69,7 +72,8 @@ test("group - active", async () => {
 
 test("group - active (animated)", async () => {
   registerCSS(
-    `.group\\/item:active .my-class {
+    `
+    .group\\/item:active .my-class {
       color: red;
       transition: color 1s;
     }`,
@@ -82,16 +86,35 @@ test("group - active (animated)", async () => {
     <View testID={parentID} className="group/item">
       <View testID={childID} className="my-class" />
     </View>,
+    {
+      logOutput: true,
+    },
   );
 
   const parent = screen.getByTestId(parentID);
   const child = screen.getByTestId(childID);
 
-  expect(child).toHaveStyle(undefined);
+  expect(getAnimatedStyle(child)).toStrictEqual({});
 
   fireEvent(parent, "pressIn");
 
-  expect(child).toHaveStyle({ color: "rgba(255, 0, 0, 1)" });
+  jest.advanceTimersByTime(0);
+
+  expect(getAnimatedStyle(child)).toStrictEqual({
+    color: "black",
+  });
+
+  jest.advanceTimersByTime(500);
+
+  expect(getAnimatedStyle(child)).toStrictEqual({
+    color: "rgba(151, 0, 0, 1)",
+  });
+
+  jest.advanceTimersByTime(500);
+
+  expect(getAnimatedStyle(child)).toStrictEqual({
+    color: "rgba(255, 0, 0, 1)",
+  });
 });
 
 test("invalid group", async () => {

--- a/packages/react-native-css-interop/src/__tests__/transitions.test.tsx
+++ b/packages/react-native-css-interop/src/__tests__/transitions.test.tsx
@@ -1,5 +1,6 @@
 /** @jsxImportSource test */
 import { View } from "react-native";
+import { getAnimatedStyle } from "react-native-reanimated";
 
 import {
   render,
@@ -9,7 +10,10 @@ import {
   fireEvent,
 } from "test";
 
+const grouping = ["^group(/.*)?"];
 const testID = "react-native-css-interop";
+const parentID = "parent";
+const childID = "child";
 setupAllComponents();
 
 jest.useFakeTimers();
@@ -174,5 +178,60 @@ test("transition - interaction", () => {
   jest.advanceTimersByTime(500);
   expect(component).toHaveAnimatedStyle({
     color: "rgba(0, 0, 255, 1)",
+  });
+});
+
+test("optional transitions", async () => {
+  registerCSS(
+    `
+    .group\\/item:active .my-class {
+      color: red;
+      transition: color 1s;
+    }`,
+    {
+      grouping,
+    },
+  );
+
+  render(
+    <View testID={parentID} className="group/item">
+      <View testID={childID} className="my-class" />
+    </View>,
+    {
+      logOutput: true,
+    },
+  );
+
+  const parent = screen.getByTestId(parentID);
+  const child = screen.getByTestId(childID);
+
+  expect(getAnimatedStyle(child)).toStrictEqual({});
+
+  fireEvent(parent, "pressIn");
+
+  jest.advanceTimersByTime(0);
+
+  expect(getAnimatedStyle(child)).toStrictEqual({
+    color: "black",
+  });
+
+  jest.advanceTimersByTime(500);
+
+  expect(getAnimatedStyle(child)).toStrictEqual({
+    color: "rgba(151, 0, 0, 1)",
+  });
+
+  jest.advanceTimersByTime(500);
+
+  expect(getAnimatedStyle(child)).toStrictEqual({
+    color: "rgba(255, 0, 0, 1)",
+  });
+
+  fireEvent(parent, "pressOut");
+
+  jest.advanceTimersByTime(0);
+
+  expect(getAnimatedStyle(child)).toStrictEqual({
+    color: "black",
   });
 });

--- a/packages/react-native-css-interop/src/runtime/native/native-interop.ts
+++ b/packages/react-native-css-interop/src/runtime/native/native-interop.ts
@@ -72,9 +72,9 @@ export function interop(
    * manage their own setup/cleanup
    */
   const sharedState = useState<SharedState>({
+    initialRender: true,
     originalProps,
     props: {},
-    guardsEnabled: false,
     canUpgradeWarn: false,
     animated: UpgradeState.NONE,
     containers: UpgradeState.NONE,
@@ -141,7 +141,7 @@ export function interop(
 
     // After the first render, we enable the guards. A guard is a function that will return true if the inputs
     // for that config has changed and needs to be updated
-    if (sharedState.guardsEnabled) {
+    if (!sharedState.initialRender) {
       if (state.declarationTracking.guards.some((guard) => guard(refs))) {
         // If needed, update the declarations
         dispatch({
@@ -293,7 +293,7 @@ export function interop(
   // Update the shared state with the latest values
   // sharedState.props = memoOutput.props;
   sharedState.originalProps = originalProps;
-  sharedState.guardsEnabled = true;
+  sharedState.initialRender = false;
 
   return renderComponent(
     component,
@@ -373,6 +373,9 @@ function getDeclarations(
       guards: [],
       previous: refs.props?.[config.source],
     },
+    // If we previously had a transition, we need to keep it
+    // So we 'reset' to the defaultTransition
+    transition: previousState.transition ? { ...defaultTransition } : undefined,
   };
 
   if (action.type === "new-declarations") {
@@ -740,51 +743,54 @@ function processTransition(
    * If there is a 'none' transition we should skip this logic.
    * In the sharedValues cleanup step the animation will be cancelled as the properties were not seen.
    */
-  if (!properties.includes("none")) {
-    for (let index = 0; index < properties.length; index++) {
-      const property = properties[index];
-      if (seenAnimatedProps.has(property)) continue;
-      let sharedValue = state.sharedValues.get(property);
-      let { value, defaultValue } = resolveTransitionValue(state, property);
+  if (properties.length === 0 || properties.includes("none")) {
+    return;
+  }
 
-      if (value === undefined && !sharedValue) {
-        // We have never seen this value, and its undefined so do nothing
-        continue;
-      } else if (!sharedValue) {
-        // First time seeing this value. On the initial render don't transition,
-        // otherwise transition from the default value
-        const initialValue =
-          Number(refs.sharedState.animated) < UpgradeState.UPGRADED &&
-          value !== undefined
-            ? value
-            : defaultValue;
+  for (let index = 0; index < properties.length; index++) {
+    const property = properties[index];
+    if (seenAnimatedProps.has(property)) continue;
+    let sharedValue = state.sharedValues.get(property);
+    let { value, defaultValue } = resolveTransitionValue(state, property);
 
-        sharedValue = makeMutable(initialValue);
+    if (value === undefined && !sharedValue) {
+      // We have never seen this value, and its undefined so do nothing
+      continue;
+    } else if (refs.sharedState.initialRender) {
+      // On the initial render don't transition
+      const initialValue = value !== undefined ? value : defaultValue;
+      sharedValue = makeMutable(initialValue);
+      state.sharedValues.set(property, sharedValue);
+    } else {
+      if (!sharedValue) {
+        // First time seeing this value, but its not the initial render!
+        // We need to create the sharedValue
+        sharedValue = makeMutable(defaultValue);
         state.sharedValues.set(property, sharedValue);
-      } else {
-        // If the value is undefined or null, then it should be the default
-        value ??= defaultValue;
-
-        if (value !== sharedValue.value) {
-          const duration = timeToMS(durations[index % durations.length]);
-          const delay = timeToMS(delays[index % delays.length]);
-          const easing = easingFunctions[index % easingFunctions.length];
-          sharedValue.value = withDelay(
-            delay,
-            withTiming(value, {
-              duration,
-              easing: getEasing(easing, Easing),
-            }),
-          );
-        }
       }
 
-      seenAnimatedProps.add(property);
-      props.style ??= {};
-      assignToTarget(props.style, sharedValue, [property], {
-        allowTransformMerging: true,
-      });
+      // If the value is undefined or null, then it should be the default
+      value ??= defaultValue;
+
+      if (value !== sharedValue.value) {
+        const duration = timeToMS(durations[index % durations.length]);
+        const delay = timeToMS(delays[index % delays.length]);
+        const easing = easingFunctions[index % easingFunctions.length];
+        sharedValue.value = withDelay(
+          delay,
+          withTiming(value, {
+            duration,
+            easing: getEasing(easing, Easing),
+          }),
+        );
+      }
     }
+
+    seenAnimatedProps.add(property);
+    props.style ??= {};
+    assignToTarget(props.style, sharedValue, [property], {
+      allowTransformMerging: true,
+    });
   }
 }
 
@@ -807,6 +813,7 @@ function retainSharedValues(
       value = value(state.styleTracking.effect);
     }
     entry[1].value = value;
+    props.style ??= {};
     props.style?.[entry[0]] ??
       state.styleLookup[entry[0]] ??
       defaultValues[entry[0]];

--- a/packages/react-native-css-interop/src/runtime/native/types.ts
+++ b/packages/react-native-css-interop/src/runtime/native/types.ts
@@ -56,9 +56,9 @@ export type Refs = {
 };
 
 export type SharedState = {
+  initialRender: boolean;
   originalProps: Record<string, any> | null;
   props: Record<string, any> | null;
-  guardsEnabled: boolean;
   animated: number;
   variables: number;
   containers: number;


### PR DESCRIPTION
Allow `<Text className="active:transition-colors active:text-red-500" />` to work.

Previously you would need to specify a non-active `color` & `transition`. Now it works like this:

- Initial render
  - No styles are rendered
  - Component is tagged as animated
- onPressIn
  - Styles are applied.
  - Text will transition from black (the default text color) to red
- onPressOut
  - Styles are applied
  - Default transition is applied (`property: []`).
  - Cleanup step resets the SharedValues to their default value
  - Text changes back to black (the default text color) with no transition (the transition was only applied on `active`)

> [!NOTE]  
> You still need to ensure that the component is animated during the initial render (`active:transition-{n}`) is fine. These classes still cannot be dynamically added