### PR TITLE
ensure that styles that have a warning are returned

### DIFF
--- a/.changeset/six-plums-stare.md
+++ b/.changeset/six-plums-stare.md
@@ -1,0 +1,5 @@
+---
+"react-native-css-interop": patch
+---
+
+ensure that styles that have a warning are returned

--- a/packages/react-native-css-interop/src/runtime/native/styles.ts
+++ b/packages/react-native-css-interop/src/runtime/native/styles.ts
@@ -69,8 +69,9 @@ export function getStyle(name: string, effect?: Effect) {
   const styleWarnings = style?.warnings;
 
   if (styleWarnings) {
-    if (warnings.has(name)) return;
-    warnings.set(name, styleWarnings);
+    if (!warnings.has(name)) {
+      warnings.set(name, styleWarnings);
+    }
   }
 
   return style;


### PR DESCRIPTION
First of all, thank you for your great work!

The current implementation of styleWarnings prevents recurring styles - which have previously set an error message - from being returned.

An example for this is gap-x-[n]. This includes following warning: `{"property": "-webkit-column-gap", "type": "IncompatibleNativeProperty"}, {"property": "-moz-column-gap", "type": "IncompatibleNativeProperty"}`.

As a warning is now set in the first run of getStyle, the style is no longer returned if the className exists a second time. 

Example: 
```
<View className="w-full gap-y-3">
  <View className="flex-row items-stretch gap-x-3">
    <View className="h-[50px] flex-1 bg-black" />
    <View className="h-[50px] flex-1 bg-black" />
  </View>
  <View className="flex-row items-stretch gap-x-3">
    <View className="h-[50px] flex-1 bg-black" />
    <View className="h-[50px] flex-1 bg-black" />
  </View>
</View>
```


This causes the following misbehavior:
<img src="https://github.com/user-attachments/assets/0bed68e6-d7fc-448e-853c-bfcbcc8aa348" alt="Simulator Screenshot - iPhone 13 mini - 2024-09-13 at 15 19 40]" width="300"/>

I see no reason not to return a style with a warning if it has already been returned.