### PR TITLE
reduce size of style output by reducing specificity size

### DIFF
--- a/.changeset/quick-crabs-jam.md
+++ b/.changeset/quick-crabs-jam.md
@@ -1,0 +1,6 @@
+---
+"react-native-css-interop": patch
+"nativewind": patch
+---
+
+reduce size of style output by reducing specificity size

--- a/packages/react-native-css-interop/src/__tests__/grouping.test.tsx
+++ b/packages/react-native-css-interop/src/__tests__/grouping.test.tsx
@@ -86,9 +86,6 @@ test("group - active (animated)", async () => {
     <View testID={parentID} className="group/item">
       <View testID={childID} className="my-class" />
     </View>,
-    {
-      logOutput: true,
-    },
   );
 
   const parent = screen.getByTestId(parentID);

--- a/packages/react-native-css-interop/src/__tests__/remap-props.test.tsx
+++ b/packages/react-native-css-interop/src/__tests__/remap-props.test.tsx
@@ -50,10 +50,7 @@ test("mapping", () => {
           ],
           pseudoClasses: undefined,
           specificity: {
-            A: 0,
             B: 1,
-            C: 0,
-            I: 0,
             O: 1,
             S: 1,
           },
@@ -76,10 +73,7 @@ test("mapping", () => {
           ],
           pseudoClasses: undefined,
           specificity: {
-            A: 0,
             B: 1,
-            C: 0,
-            I: 0,
             O: 2,
             S: 1,
           },

--- a/packages/react-native-css-interop/src/__tests__/transitions.test.tsx
+++ b/packages/react-native-css-interop/src/__tests__/transitions.test.tsx
@@ -197,9 +197,6 @@ test("optional transitions", async () => {
     <View testID={parentID} className="group/item">
       <View testID={childID} className="my-class" />
     </View>,
-    {
-      logOutput: true,
-    },
   );
 
   const parent = screen.getByTestId(parentID);

--- a/packages/react-native-css-interop/src/css-to-rn/index.ts
+++ b/packages/react-native-css-interop/src/css-to-rn/index.ts
@@ -411,10 +411,12 @@ function setStyleForSelectorList(
         media,
       } = selector;
 
-      const specificity = {
-        ...extractedStyle.specificity,
-        ...selector.specificity,
-      };
+      const specificity = Object.fromEntries(
+        Object.entries({
+          ...extractedStyle.specificity,
+          ...selector.specificity,
+        }).filter(([, value]) => value !== 0),
+      );
 
       if (groupClassName) {
         // Add the conditions to the declarations object

--- a/packages/react-native-css-interop/src/runtime/native/native-interop.ts
+++ b/packages/react-native-css-interop/src/runtime/native/native-interop.ts
@@ -1004,7 +1004,7 @@ function applyRules(
   }
 }
 
-const inlineSpecificity: Specificity = { inline: 1, I: 0 };
+const inlineSpecificity: Specificity = { inline: 1 };
 function specificityCompare(
   o1?: object | StyleRule | null,
   o2?: object | StyleRule | null,


### PR DESCRIPTION
Removes unused `specificity` values from the generated styles