### PR TITLE
Bump dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -70,17 +70,17 @@
       }
     },
     "apps/website": {
-      "version": "0.0.45",
+      "version": "0.0.48",
       "dependencies": {
         "@docusaurus/core": "3.0.0",
         "@docusaurus/preset-classic": "3.0.0",
         "@mdx-js/react": "3.0.0",
         "@types/lodash.debounce": "4.0.8",
         "docusaurus-plugin-sass": "0.2.5",
-        "nativewind": "4.1.6",
+        "nativewind": "4.1.10",
         "react": "18.2.0",
         "react-dom": "18.2.0",
-        "react-native-css-interop": "0.1.5",
+        "react-native-css-interop": "0.1.9",
         "react-twitter-embed": "4.0.4",
         "sass": "1.69.5",
         "tailwindcss": "3.4.4"
@@ -88,7 +88,7 @@
     },
     "examples/expo-router": {
       "name": "nativewind-expo-router",
-      "version": "1.0.45",
+      "version": "1.0.48",
       "dependencies": {
         "@changesets/cli": "^2.26.2",
         "@expo/vector-icons": "^14.0.0",
@@ -102,7 +102,7 @@
         "expo-status-bar": "~1.12.1",
         "expo-system-ui": "~3.0.7",
         "expo-web-browser": "~13.0.3",
-        "nativewind": "4.1.6",
+        "nativewind": "4.1.10",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-native": "0.74.5",
@@ -34917,11 +34917,11 @@
       }
     },
     "packages/nativewind": {
-      "version": "4.1.6",
+      "version": "4.1.10",
       "license": "MIT",
       "dependencies": {
         "comment-json": "^4.2.5",
-        "react-native-css-interop": "0.1.5"
+        "react-native-css-interop": "0.1.9"
       },
       "devDependencies": {
         "@tailwindcss/container-queries": "^0.1.1",
@@ -34942,7 +34942,7 @@
       }
     },
     "packages/react-native-css-interop": {
-      "version": "0.1.5",
+      "version": "0.1.9",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.22.15",


### PR DESCRIPTION
It seems that not all libraries are up to date when running `npm i` in the root of the directory. This is just a PR to update the `package-lock.json`, accordingly.