### PR TITLE
improve UX for debugging test output

### DIFF
--- a/packages/nativewind/src/test.tsx
+++ b/packages/nativewind/src/test.tsx
@@ -79,7 +79,9 @@ export async function renderCurrentTest({
   }
 }
 
-let isCompilerLoggingEnabled = false;
+renderCurrentTest.debug = (options: RenderCurrentTestOptions = {}) => {
+  return renderCurrentTest({ ...options, logOutput: true });
+};
 
 export async function render(
   component: React.ReactElement<any>,
@@ -93,8 +95,6 @@ export async function render(
   }).reduce((acc, [layer, enabled]) => {
     return enabled ? `${acc}@tailwind ${layer};` : acc;
   }, "");
-  logOutput ||= isCompilerLoggingEnabled;
-
   const content = getClassNames(component);
 
   if (logOutput) {
@@ -124,9 +124,12 @@ export async function render(
   });
 }
 
-export function enableCompilerLogging(enable: boolean) {
-  isCompilerLoggingEnabled = enable;
-}
+render.debug = (
+  component: React.ReactElement<any>,
+  options: RenderOptions = {},
+) => {
+  return render(component, { ...options, logOutput: true });
+};
 
 function getClassNames(
   component: React.ReactElement<any>,

--- a/packages/react-native-css-interop/src/test/index.tsx
+++ b/packages/react-native-css-interop/src/test/index.tsx
@@ -63,8 +63,8 @@ export interface RenderOptions extends TLRenderOptions {
   logOutput?: boolean;
 }
 
-export function render<T>(
-  component: ReactElement<T>,
+export function render(
+  component: ReactElement<any>,
   { css, cssOptions, ...options }: RenderOptions = {},
 ) {
   if (options.logOutput) {
@@ -83,6 +83,10 @@ export function render<T>(
     ...options,
   });
 }
+
+render.debug = (component: ReactElement<any>, options: RenderOptions = {}) => {
+  return render(component, { ...options, logOutput: true });
+};
 
 export function getWarnings() {
   return warnings;


### PR DESCRIPTION
Allow for `renderCurrentTest.debug()` / `render.debug()` to most easily toggle debugging output in tests.