### PR TITLE
Revert "support tvos (#1061)"

### DIFF
--- a/.changeset/metal-eyes-cover.md
+++ b/.changeset/metal-eyes-cover.md
@@ -1,0 +1,5 @@
+---
+"react-native-css-interop": patch
+---
+
+Revert TV support (changes will be made in RNTV repo)

--- a/packages/react-native-css-interop/src/runtime/native/native-interop.ts
+++ b/packages/react-native-css-interop/src/runtime/native/native-interop.ts
@@ -6,7 +6,7 @@ import {
   useReducer,
   useState,
 } from "react";
-import { LayoutChangeEvent, Platform, View } from "react-native";
+import { LayoutChangeEvent, View } from "react-native";
 import {
   ReactComponent,
   InteropComponentConfig,
@@ -48,7 +48,6 @@ import {
 } from "./styles";
 import { DEFAULT_CONTAINER_NAME } from "../../shared";
 import { assignToTarget, getTargetValue } from "./utils";
-import { GestureHandlerEvent } from "react-native-reanimated/lib/typescript/reanimated2/hook";
 
 export function interop(
   component: ReactComponent<any>,
@@ -168,8 +167,7 @@ export function interop(
     let containers: ContainerRecord = {};
 
     const possiblyAnimatedProps: Record<string, any> = {};
-    const handlers: Record<string, (event: GestureHandlerEvent<any>) => void> =
-      {};
+    const handlers: Record<string, any> = {};
 
     let hasNullContainer = false;
 
@@ -235,35 +233,9 @@ export function interop(
       if (component === View) {
         sharedState.pressable ||= UpgradeState.SHOULD_UPGRADE;
       }
-      let tvTimeout: NodeJS.Timeout;
-      handlers.onPress = (event) => {
+      handlers.onPress = (event: unknown) => {
         sharedState.originalProps?.onPress?.(event);
-
-        /**
-         * tvOS does not receive pressIn/pressOut
-         * so we need to fake it via onPress or
-         * handle in onLongPress
-         */
-        if (Platform.isTV) {
-          sharedState.active!.set(true);
-          clearTimeout(tvTimeout);
-          tvTimeout = setTimeout(() => {
-            sharedState.active!.set(false);
-          }, 50);
-        }
       };
-
-      /**
-       * tvOS does not receive pressIn/pressOut
-       * so we need to fake it via onPress or
-       * handle in onLongPress
-       */
-      if (Platform.isTV) {
-        handlers.onLongPress = (event) => {
-          sharedState.originalProps?.onLongPress?.(event);
-          sharedState.active!.set(event.eventKeyAction === 0);
-        };
-      }
     }
 
     if (sharedState.layout || sharedState.containers) {


### PR DESCRIPTION
It would probably be a better separation of concerns, and more maintainable and configurable, to revert this change. Instead, I propose to modify RNTV to send the expected `onPressIn` and `onPressOut` methods when controls are selected.

For example, the TV repo could add a new prop to `Pressable` and `Touchable` to configure the amount of time `active` is true when the TV remote selects a control.

Example of what the RNTV change might look like: https://github.com/douglowder/NativeWindTV/blob/doug/nativewind-v4/patches/react-native%2B0.74.5-0.patch