### PR TITLE
add `DEBUG=nativewind` for Metro debugging

### DIFF
--- a/.changeset/large-eels-work.md
+++ b/.changeset/large-eels-work.md
@@ -1,0 +1,6 @@
+---
+"react-native-css-interop": patch
+"nativewind": patch
+---
+
+add `DEBUG=nativewind` for Metro debugging

--- a/package-lock.json
+++ b/package-lock.json
@@ -37983,6 +37983,7 @@
       "license": "MIT",
       "dependencies": {
         "comment-json": "^4.2.5",
+        "debug": "^4.3.7",
         "react-native-css-interop": "0.1.9"
       },
       "devDependencies": {
@@ -38010,6 +38011,7 @@
         "@babel/helper-module-imports": "^7.22.15",
         "@babel/traverse": "^7.23.0",
         "@babel/types": "^7.23.0",
+        "debug": "^4.3.7",
         "lightningcss": "1.27.0",
         "semver": "^7.6.3"
       },

--- a/packages/nativewind/package.json
+++ b/packages/nativewind/package.json
@@ -55,8 +55,9 @@
     "types.d.ts"
   ],
   "dependencies": {
-    "react-native-css-interop": "0.1.9",
-    "comment-json": "^4.2.5"
+    "comment-json": "^4.2.5",
+    "debug": "^4.3.7",
+    "react-native-css-interop": "0.1.9"
   },
   "devDependencies": {
     "@tailwindcss/container-queries": "^0.1.1",

--- a/packages/nativewind/src/metro/index.ts
+++ b/packages/nativewind/src/metro/index.ts
@@ -1,4 +1,5 @@
 import type { MetroConfig } from "metro-config";
+import { debug as debugFn } from "debug";
 import path from "path";
 import {
   withCssInterop,
@@ -21,6 +22,8 @@ interface WithNativeWindOptions extends WithCssInteropOptions {
   disableTypeScriptGeneration?: boolean;
 }
 
+const debug = debugFn("nativewind");
+
 export function withNativeWind(
   config: MetroConfig,
   {
@@ -35,11 +38,16 @@ export function withNativeWind(
 ): MetroConfig {
   if (input) input = path.resolve(input);
 
+  debug(`input: ${input}`);
+
   const { important } = tailwindConfig(path.resolve(tailwindConfigPath));
 
-  const cli = tailwindCli();
+  debug(`important: ${important}`);
+
+  const cli = tailwindCli(debug);
 
   if (!disableTypeScriptGeneration) {
+    debug(`checking TypeScript setup`);
     setupTypeScript(typescriptEnvPath);
   }
 
@@ -48,7 +56,9 @@ export function withNativeWind(
     inlineRem,
     selectorPrefix: typeof important === "string" ? important : undefined,
     input,
+    debug,
     processPROD: (platform) => {
+      debug(`processPROD: ${platform}`);
       return cli.processPROD({
         platform,
         input,
@@ -57,6 +67,7 @@ export function withNativeWind(
       });
     },
     processDEV: (platform, onChange) => {
+      debug(`processDEV: ${platform}`);
       return cli.processDEV({
         platform,
         input,

--- a/packages/nativewind/src/metro/tailwind/index.ts
+++ b/packages/nativewind/src/metro/tailwind/index.ts
@@ -1,11 +1,12 @@
 import tailwindPackage from "tailwindcss/package.json";
 import { tailwindCliV3, tailwindConfigV3 } from "./v3";
+import { Debugger } from "debug";
 
 const isV3 = tailwindPackage.version.split(".")[0].includes("3");
 
-export function tailwindCli() {
+export function tailwindCli(debug: Debugger) {
   if (isV3) {
-    return tailwindCliV3;
+    return tailwindCliV3(debug);
   }
 
   throw new Error("NativeWind only supports Tailwind CSS v3");

--- a/packages/react-native-css-interop/package.json
+++ b/packages/react-native-css-interop/package.json
@@ -55,6 +55,7 @@
     "@babel/helper-module-imports": "^7.22.15",
     "@babel/traverse": "^7.23.0",
     "@babel/types": "^7.23.0",
+    "debug": "^4.3.7",
     "lightningcss": "1.27.0",
     "semver": "^7.6.3"
   },

--- a/packages/react-native-css-interop/src/types.ts
+++ b/packages/react-native-css-interop/src/types.ts
@@ -42,6 +42,7 @@ export type InteropComponentConfig = {
 };
 
 export type CssToReactNativeRuntimeOptions = {
+  debug?: (str: string) => void;
   inlineRem?: number | false;
   grouping?: (string | RegExp)[];
   ignorePropertyWarningRegex?: (string | RegExp)[];


### PR DESCRIPTION
Add debug output when `DEBUG=nativewind`  is set.

```
➜  expo-router git:(main) ✗ DEBUG=nativewind npx expo start        
Starting project at /Users/mark/Projects/nativewind/examples/expo-router
  nativewind input: /Users/mark/Projects/nativewind/examples/expo-router/global.css +0ms
  nativewind important: undefined +26ms
  nativewind checking TypeScript setup +0ms
  nativewind withCssInterop: successfully called +82ms
  nativewind platforms: ios,android,web,native +0ms
  nativewind prodOutputDir: /Users/mark/Projects/nativewind/packages/react-native-css-interop/.cache +0ms
Starting Metro Bundler
  nativewind enhanceMiddleware successfully called +229ms

› Metro waiting on exp://192.168.1.4:8081
› Scan the QR code above with Expo Go (Android) or the Camera app (iOS)

› Web is waiting on http://localhost:8081

› Using Expo Go
› Press s │ switch to development build

› Press a │ open Android
› Press i │ open iOS simulator
› Press w │ open web

› Press j │ open debugger
› Press r │ reload app
› Press m │ toggle menu
› Press o │ open project code in your editor

› Press ? │ show all commands

Logs for your project will appear below. Press Ctrl+C to exit.
› Opening on iOS...
› Opening exp://192.168.1.4:8081 on iPhone 15
› Press ? │ show all commands
› Reloading apps
iOS ./index.js ▓░░░░░░░░░░░░░░░  7.0% ( 66/249)  
  nativewind resolveRequest: found input +11s
  nativewind resolveRequest.isDev true +0ms
  nativewind platformFilePath: /Users/mark/Projects/nativewind/examples/expo-router/global.css.ios.js +0ms
  nativewind processDEV: ios +0ms
iOS ./index.js ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓░ 99.8% (1181/1182)  
  nativewind Features {"transformPercentagePolyfill":false,"disableGapPercentageValues":false,"disableDisplayBlock":false,"disableAlignContentEvenly":false,"disablePositionStatic":false} +1s
  nativewind Grouping /^group(\/.*)?/ +0ms
  nativewind Start lightningcss +0ms
  nativewind StyleSheetExit +154ms
  nativewind Extraction of 14216 rules finished +110ms
  nativewind Start optimizing rules +10ms
  nativewind Finishing optimization +1s
  nativewind Rule set count: 14206 +0ms
  nativewind Start stringify +0ms
  nativewind Finished stringify +68ms
  nativewind Output size: 3396879 bytes +0ms
iOS Bundled 7360ms index.js (1182 modules)
 LOG  nativewind parse time: 29ms
  nativewind Features {"transformPercentagePolyfill":false,"disableGapPercentageValues":false,"disableDisplayBlock":false,"disableAlignContentEvenly":false,"disablePositionStatic":false} +13s
  nativewind Grouping /^group(\/.*)?/ +0ms
  nativewind Start lightningcss +0ms
  nativewind StyleSheetExit +202ms
  nativewind Extraction of 14217 rules finished +198ms
  nativewind Start optimizing rules +23ms
  nativewind Finishing optimization +1s
  nativewind Rule set count: 14207 +0ms
  nativewind Start stringify +0ms
  nativewind Finished stringify +65ms
  nativewind Output size: 3397109 bytes +1ms
  nativewind Firing change event to Metro +0ms
 LOG  Fast Refresh took: 4927ms
 LOG  nativewind parse time: 45ms
```