### PR TITLE
Avoid transforming styles JS file

### DIFF
--- a/.changeset/pink-students-kneel.md
+++ b/.changeset/pink-students-kneel.md
@@ -1,0 +1,6 @@
+---
+"react-native-css-interop": patch
+"nativewind": patch
+---
+
+avoid transforming the styles JS file

--- a/packages/nativewind/src/metro/index.ts
+++ b/packages/nativewind/src/metro/index.ts
@@ -55,8 +55,8 @@ export function withNativeWind(
     ...cssToReactNativeRuntimeOptions,
     inlineRem,
     selectorPrefix: typeof important === "string" ? important : undefined,
+    debugNamespace: "nativewind",
     input,
-    debug,
     processPROD: (platform) => {
       debug(`processPROD: ${platform}`);
       return cli.processPROD({

--- a/packages/react-native-css-interop/src/metro/transformer.ts
+++ b/packages/react-native-css-interop/src/metro/transformer.ts
@@ -1,0 +1,67 @@
+import worker, {
+  JsTransformerConfig,
+  JsTransformOptions,
+  TransformResponse,
+} from "metro-transform-worker";
+
+interface TransformerConfig extends JsTransformerConfig {
+  originalTransformerPath?: string;
+}
+
+export async function transform(
+  config: TransformerConfig,
+  projectRoot: string,
+  filename: string,
+  data: Buffer,
+  options: JsTransformOptions,
+): Promise<TransformResponse> {
+  const transform = config.originalTransformerPath
+    ? require(config.originalTransformerPath).transform
+    : worker.transform;
+
+  if (filename.match(/.css.ios.js$/)) {
+    const debugEnabled = "debugEnabled" in config && config.debugEnabled;
+
+    if (debugEnabled) {
+      console.time("Transforming style JS file");
+    }
+    /**
+     * The style object can be quite large and running it though a transform can be quite costly
+     * Since the style file only uses a single import, we can transform a fake file to get the
+     * dependencies and function mapping
+     *
+     * We just need to ensure that the code we generate matches the code Metro would generate
+     */
+    const result = await transform(
+      config,
+      projectRoot,
+      filename,
+      Buffer.from(
+        `require("react-native-css-interop/dist/runtime/native/styles")`,
+      ),
+      options,
+    );
+
+    const code = data.toString("utf-8");
+
+    if (debugEnabled) {
+      console.timeEnd("Transforming style JS file");
+    }
+
+    return {
+      dependencies: result.dependencies,
+      output: [
+        {
+          data: {
+            code,
+            lineCount: code.split("\n").length,
+            functionMap: result.output[0].data.functionMap,
+          },
+          type: result.output[0].type,
+        },
+      ],
+    };
+  }
+
+  return transform(config, projectRoot, filename, data, options);
+}


### PR DESCRIPTION
Some projects generate an huge amount of styles which lead to large generated JS files.

When NativeWind updates a style, this entire file is passed to Metro and subsequently transformed via Babel. Locally using ~14000 styles a Fast Refresh update may take ~8 seconds.

This PR adds a custom transform that skips transforming the large JS bundle. This reduces the Fast Refresh time to ~2.5s.

For reference, Metro takes ~700ms to complete a standard Fast Refresh (from sending the file changed event to appearing on device). So ~2.5s is still not ideal, but there are other known issues that will be fixed in other PRs. 

Numbers are reference only. Just recorded values on my machine while testing.

cc: @Viraj-10 