### PR TITLE
Spawn TailwindCLI using the current NodeJS binary

### DIFF
--- a/packages/nativewind/src/metro/tailwind/v3/index.ts
+++ b/packages/nativewind/src/metro/tailwind/v3/index.ts
@@ -1,4 +1,5 @@
 import { execSync, fork } from "child_process";
+import { execPath } from "node:process";
 import fs from "fs";
 import path from "path";
 import { type Config } from "tailwindcss";
@@ -48,7 +49,10 @@ export const tailwindCliV3 = function (debug: Debugger) {
         `${path.basename(options.input)}.${options.platform}.css`,
       );
 
-      execSync(`${cliLocation} --input ${options.input} --output ${output}`, {
+      const cliCommand = `${execPath} ${cliLocation} --input ${options.input} --output ${output}`;
+      debug(`PROD execSync: ${cliCommand}`);
+
+      execSync(cliCommand, {
         env: getEnv(options),
       });
 


### PR DESCRIPTION
XCode isn't always configured to run NodeJS. Since we are already in a NodeJS process, we can spawn the Tailwind CLI using the same binary.