### PR TITLE
Add runtime shorthand parsing

### DIFF
--- a/.changeset/poor-guests-hide.md
+++ b/.changeset/poor-guests-hide.md
@@ -1,0 +1,6 @@
+---
+"react-native-css-interop": patch
+"nativewind": patch
+---
+
+Support parsing text-shadow CSS rules

--- a/packages/nativewind/src/__tests__/unofficial-plugins.test.ios.tsx
+++ b/packages/nativewind/src/__tests__/unofficial-plugins.test.ios.tsx
@@ -6,8 +6,10 @@
  * They are not officially supported by NativeWind
  */
 
-import { View } from "react-native";
+import { Text, View } from "react-native";
 import { render, screen } from "../test";
+import plugin from "tailwindcss/plugin";
+import flattenColorPalette from "tailwindcss/lib/util/flattenColorPalette";
 
 const testID = "nativewind";
 
@@ -52,5 +54,116 @@ test("tw-colors", async () => {
 
   expect(screen.getByTestId(testID)).toHaveStyle({
     color: "hsla(240, 100%, 50%, 1)",
+  });
+});
+
+test("text-shadow", async () => {
+  const textShadowPlugin = plugin(
+    function ({ addBase, matchUtilities, matchComponents, theme }: any) {
+      addBase({
+        ":root": {
+          "--ts-text-shadow-color": "rgba(0, 0,0,0.50)",
+          "--ts-text-shadow-x": "1px",
+          "--ts-text-shadow-y": "1px",
+          "--ts-text-shadow-blur": "2px",
+        },
+      });
+
+      matchUtilities(
+        {
+          [`text-shadow-x`]: (value: Record<string, string>) => ({
+            "--ts-text-shadow-x": value,
+          }),
+          [`text-shadow-y`]: (value: Record<string, string>) => ({
+            "--ts-text-shadow-y": value,
+          }),
+          [`text-shadow-blur`]: (value: Record<string, string>) => ({
+            "--ts-text-shadow-blur": value,
+          }),
+        },
+        {
+          values: theme("textShadowSteps"),
+          type: "length",
+          supportsNegativeValues: true,
+        },
+      );
+
+      matchUtilities(
+        {
+          [`text-shadow`]: (value: Record<string, string>) => ({
+            "--ts-text-shadow-color": value,
+          }),
+        },
+        {
+          values: flattenColorPalette(theme("colors")),
+          type: "color",
+        },
+      );
+
+      matchComponents(
+        {
+          [`text-shadow`]: (value: number) => ({
+            textShadow:
+              value === 1
+                ? `var(--ts-text-shadow-x) var(--ts-text-shadow-y) var(--ts-text-shadow-blur) var(--ts-text-shadow-color)`
+                : `calc(var(--ts-text-shadow-x) * ${value}) calc(var(--ts-text-shadow-y) * ${value}) var(--ts-text-shadow-blur) var(--ts-text-shadow-color)`,
+          }),
+        },
+        {
+          type: "number",
+          values: theme("textShadowMultiplier"),
+        },
+      );
+    },
+    {
+      theme: {
+        experimental: false,
+        textShadowMultiplier: {
+          DEFAULT: 1,
+          sm: 4,
+          md: 8,
+          lg: 12,
+          xl: 16,
+        },
+        textShadowSteps: {
+          xs: "1px",
+          sm: "2px",
+          md: "3px",
+          lg: "4px",
+          xl: "5px",
+          0: "0",
+          1: "1px",
+          2: "2px",
+          3: "3px",
+          4: "4px",
+          5: "5px",
+          6: "6px",
+          7: "7px",
+          8: "8px",
+          9: "9px",
+          10: "10px",
+        },
+      },
+    },
+  );
+
+  await render(
+    <Text testID={testID} className="text-shadow-lg text-shadow-red-500" />,
+    {
+      config: {
+        plugins: [textShadowPlugin],
+      },
+    },
+  );
+
+  const text = screen.getByTestId(testID);
+
+  expect(text).toHaveStyle({
+    textShadowColor: "#ef4444",
+    textShadowOffset: {
+      height: 12,
+      width: 12,
+    },
+    textShadowRadius: 2,
   });
 });

--- a/packages/react-native-css-interop/src/__tests__/shorthand.test.tsx
+++ b/packages/react-native-css-interop/src/__tests__/shorthand.test.tsx
@@ -1,0 +1,58 @@
+/** @jsxImportSource test */
+import { Text } from "react-native";
+import { render, registerCSS, setupAllComponents, screen, testID } from "test";
+
+setupAllComponents();
+
+describe("text-shadow", () => {
+  test("<offsetX> <offsetY>", () => {
+    registerCSS(
+      `.my-class { --my-var: 10px 10px; text-shadow: var(--my-var); }`,
+    );
+
+    render(<Text testID={testID} className="my-class" />);
+
+    expect(screen.getByTestId(testID)).toHaveStyle({
+      textShadowColor: "black",
+      textShadowOffset: {
+        height: 10,
+        width: 10,
+      },
+      textShadowRadius: 0,
+    });
+  });
+
+  test("<color> <offsetX> <offsetY>", () => {
+    registerCSS(
+      `.my-class { --my-var: 10px 10px; text-shadow: red var(--my-var); }`,
+    );
+
+    render(<Text testID={testID} className="my-class" />);
+
+    expect(screen.getByTestId(testID)).toHaveStyle({
+      textShadowColor: "red",
+      textShadowOffset: {
+        height: 10,
+        width: 10,
+      },
+      textShadowRadius: 0,
+    });
+  });
+
+  test("<offsetX> <offsetY> <color>", () => {
+    registerCSS(
+      `.my-class { --my-var: 10px 10px; text-shadow: var(--my-var) red; }`,
+    );
+
+    render(<Text testID={testID} className="my-class" />);
+
+    expect(screen.getByTestId(testID)).toHaveStyle({
+      textShadowColor: "red",
+      textShadowOffset: {
+        height: 10,
+        width: 10,
+      },
+      textShadowRadius: 0,
+    });
+  });
+});

--- a/packages/react-native-css-interop/src/css-to-rn/parseDeclaration.ts
+++ b/packages/react-native-css-interop/src/css-to-rn/parseDeclaration.ts
@@ -51,6 +51,8 @@ import type {
   RuntimeFunction,
 } from "../types";
 import { FeatureFlagStatus } from "./feature-flags";
+import { isDescriptorArray } from "../shared";
+import { toRNProperty } from "./normalize-selectors";
 
 const unparsedPropertyMapping: Record<string, string> = {
   "margin-inline-start": "margin-start",
@@ -330,6 +332,14 @@ export function parseDeclaration(
     let property =
       unparsedPropertyMapping[declaration.value.propertyId.property] ||
       declaration.value.propertyId.property;
+
+    if (unparsedRuntimeFn.has(property)) {
+      let args = parseUnparsed(declaration.value.value, parseOptions);
+      if (!isDescriptorArray(args)) {
+        args = [args];
+      }
+      return addStyleProp(property, [{}, `@${toRNProperty(property)}`, args]);
+    }
 
     return addStyleProp(
       property,
@@ -2921,3 +2931,5 @@ export function parseUnresolvedColor(
       color satisfies never;
   }
 }
+
+const unparsedRuntimeFn = new Set(["text-shadow"]);

--- a/packages/react-native-css-interop/src/runtime/native/native-interop.ts
+++ b/packages/react-native-css-interop/src/runtime/native/native-interop.ts
@@ -701,7 +701,8 @@ function resetAnimation(state: ReducerState) {
       require("react-native-reanimated") as typeof import("react-native-reanimated");
 
     for (const [propertyName] of animation.frames) {
-      let defaultValue = defaultValues[propertyName];
+      let defaultValue =
+        defaultValues[propertyName as keyof typeof defaultValues];
 
       if (typeof defaultValue === "function") {
         defaultValue = defaultValue(state.styleTracking.effect);
@@ -806,13 +807,16 @@ function retainSharedValues(
 
   for (const entry of state.sharedValues) {
     if (seenAnimatedProps.has(entry[0])) continue;
-    let value = props.style?.[entry[0]] ?? defaultValues[entry[0]];
+    let value =
+      props.style?.[entry[0]] ??
+      defaultValues[entry[0] as keyof typeof defaultValues];
     if (typeof value === "function") {
       value = value(state.styleTracking.effect);
     }
     entry[1].value = value;
     props.style ??= {};
-    props.style?.[entry[0]] ?? defaultValues[entry[0]];
+    props.style?.[entry[0]] ??
+      defaultValues[entry[0] as keyof typeof defaultValues];
     assignToTarget(props.style, entry[1], [entry[0]], {
       allowTransformMerging: true,
     });

--- a/packages/react-native-css-interop/src/runtime/native/resolvers/shared.ts
+++ b/packages/react-native-css-interop/src/runtime/native/resolvers/shared.ts
@@ -1,0 +1,1 @@
+export const ShorthandSymbol = Symbol();

--- a/packages/react-native-css-interop/src/runtime/native/resolvers/shorthand.ts
+++ b/packages/react-native-css-interop/src/runtime/native/resolvers/shorthand.ts
@@ -1,0 +1,80 @@
+import { isDescriptorArray } from "../../../shared";
+import { defaultValues } from "../resolve-value";
+import type { ShorthandResolveFn, ShorthandResultArray } from "../types";
+import { ShorthandSymbol } from "./shared";
+
+type ShorthandRequiredValue =
+  | readonly [
+      string | readonly string[],
+      "string" | "number" | "length" | "color",
+    ]
+  | ShorthandDefaultValue;
+
+type ShorthandDefaultValue = readonly [
+  string | readonly string[],
+  "string" | "number" | "length" | "color",
+  keyof typeof defaultValues,
+];
+
+export function shorthandHandler(
+  mappings: ShorthandRequiredValue[][],
+  defaults: ShorthandDefaultValue[],
+) {
+  const resolveFn: ShorthandResolveFn = (
+    resolve,
+    state,
+    refs,
+    tracking,
+    descriptor,
+    style,
+  ) => {
+    if (!isDescriptorArray(descriptor)) return;
+
+    const resolved = descriptor.flatMap((value) => {
+      return resolve(state, refs, tracking, value, style);
+    });
+
+    const match = mappings.find((mapping) => {
+      return mapping.every((map, index) => {
+        const type = map[1];
+        const value = resolved[index];
+
+        switch (type) {
+          case "string":
+          case "number":
+            return typeof value === type;
+          case "color":
+            return typeof value === "string" || typeof value === "object";
+          case "length":
+            return typeof value === "string"
+              ? value.endsWith("%")
+              : typeof value === "number";
+        }
+      });
+    });
+
+    if (!match) return;
+
+    const seenDefaults = new Set(defaults);
+
+    const result: ShorthandResultArray = [
+      ...match.map((map, index) => {
+        if (map.length === 3) {
+          seenDefaults.delete(map);
+        }
+        return [map[0], resolved[index]] as const;
+      }),
+      ...Array.from(seenDefaults).map((map) => {
+        const value = defaultValues[map[2]];
+        return [
+          map[0],
+          typeof value === "function" ? value(tracking.effect) : value,
+        ] as const;
+      }),
+    ];
+
+    return Object.assign(result, { [ShorthandSymbol]: true });
+  };
+
+  return resolveFn;
+}

--- a/packages/react-native-css-interop/src/runtime/native/resolvers/text-shadow.ts
+++ b/packages/react-native-css-interop/src/runtime/native/resolvers/text-shadow.ts
@@ -1,0 +1,17 @@
+import { shorthandHandler } from "./shorthand";
+
+const width = [["textShadowOffset", "width"], "number"] as const;
+const height = [["textShadowOffset", "height"], "number"] as const;
+const blur = ["textShadowRadius", "number", "textShadowRadius"] as const;
+const color = ["textShadowColor", "color", "color"] as const;
+
+export const textShadow = shorthandHandler(
+  [
+    [width, height, blur, color],
+    [color, width, height, blur],
+    [width, height, color],
+    [color, width, height],
+    [width, height],
+  ],
+  [blur, color],
+);

--- a/packages/react-native-css-interop/src/runtime/native/types.ts
+++ b/packages/react-native-css-interop/src/runtime/native/types.ts
@@ -5,9 +5,12 @@ import type {
   ExtractedTransition,
   ContainerRecord,
   StyleDeclaration,
+  RuntimeValueDescriptor,
 } from "../../types";
 import type { Effect, Observable } from "../observable";
 import type { VariableContextValue } from "./styles";
+import { PLACEHOLDER_SYMBOL } from "../../shared";
+import { ShorthandSymbol } from "./resolvers/shared";
 
 export type Callback = () => void;
 export type GetInteraction = (
@@ -68,3 +71,28 @@ export type SharedState = {
 };
 
 export type RenderingGuard = (refs: Refs) => boolean;
+
+export type ShorthandResolveFn = (
+  resolve: (
+    state: ReducerState,
+    refs: Refs,
+    tracking: ReducerTracking,
+    descriptor: RuntimeValueDescriptor | RuntimeValueDescriptor[],
+    style?: Record<string, any>,
+  ) => any,
+  state: ReducerState,
+  refs: Refs,
+  tracking: ReducerTracking,
+  descriptor: RuntimeValueDescriptor | RuntimeValueDescriptor[],
+  style?: Record<string, any>,
+) => ShorthandResult | undefined;
+
+export type ShorthandResultArray = Array<
+  readonly [string | readonly string[], any]
+>;
+
+export type ShorthandResult = ShorthandResultArray & {
+  [ShorthandSymbol]: boolean;
+};
+
+export type Placeholder = { [PLACEHOLDER_SYMBOL]: boolean };

--- a/packages/react-native-css-interop/src/test/index.tsx
+++ b/packages/react-native-css-interop/src/test/index.tsx
@@ -160,6 +160,8 @@ registerCSS.noDebug = (
   registerCSS(css, { ...options, debugCompiled: false });
 };
 
+export const testID = "react-native-css-interop";
+
 export function setupAllComponents() {
   require("../runtime/components");
 }


### PR DESCRIPTION
Add support for runtime shorthand parsing. This allows people to use CSS variables to for multiple shorthand values.

PR only adds support for `text-shadow`, as each shorthand needs its syntax added.