### PR TITLE
Allow bg-opacity- on native

### DIFF
--- a/packages/nativewind/src/tailwind/native.ts
+++ b/packages/nativewind/src/tailwind/native.ts
@@ -352,7 +352,6 @@ const preset: Config = {
   ],
   corePlugins: {
     preflight: false,
-    backgroundOpacity: false,
     borderOpacity: false,
     boxShadow: false,
     caretColor: false,


### PR DESCRIPTION
I eventually chased this down as why bg-opacity- was working on web but wasn't working on mobile, and found that it's explicitly disabled on native. Is this a relic of pre-v4 where it didn't work? I've tested it on iOS and it works. I'm not sure what other testing to do, and I also suspect other opacity-related plugins could be enabled.