### PR TITLE
fix(docs): fix the docs tab item label to reflect the correct configuration

### DIFF
--- a/apps/website/docs/getting-started/expo-router.mdx
+++ b/apps/website/docs/getting-started/expo-router.mdx
@@ -57,7 +57,7 @@ import Tailwind from "./_tailwind.mdx";
 If your project does not have a `metro.config.js` run `npx expo customize metro.config.js`
 
 <Tabs>
-<TabItem value="SDK 49">
+<TabItem value="SDK 50+">
 
 ```js title="metro.config.js"
 const { getDefaultConfig } = require("expo/metro-config");
@@ -69,7 +69,7 @@ module.exports = withNativeWind(config, { input: "./global.css" });
 ```
 
 </TabItem>
-<TabItem value="SDK 50+">
+<TabItem value="SDK 49">
 
 ```js title="metro.config.js"
 const { getDefaultConfig } = require("expo/metro-config");


### PR DESCRIPTION


I believe there is a mismatch between the Expo version and the correct configuration. This is a simple fix at least based on the example folder