### PR TITLE
Introducing NativeWind Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 [![Github](https://img.shields.io/github/license/marklawlor/nativewind)](https://github.com/nativewind/nativewind)
 [![Discord](https://img.shields.io/discord/968718419904057416?logo=discord&logoColor=ffffff&label=Discord&color=%235865F2)](https://discord.gg/ypNakAFQ65)
 [![Twitter](https://img.shields.io/twitter/follow/nativewindcss?link=https%3A%2F%2Fx.com%2Ftailwindcss)](https://x.com/nativewindcss)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20NativeWind%20Guru-006BFF)](https://gurubase.io/g/nativewind)
 
 </div>
 <br />


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [NativeWind Guru](https://gurubase.io/g/nativewind) to Gurubase. NativeWind Guru uses the data from this repo and data from the [docs](https://nativewind.dev) to answer questions by leveraging the LLM.

In this PR, I showcased the "NativeWind Guru", which highlights that NativeWind now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable NativeWind Guru in Gurubase, just let me know that's totally fine.
