### PR TITLE
Update _install.mdx

### DIFF
--- a/apps/website/docs/getting-started/_install.mdx
+++ b/apps/website/docs/getting-started/_install.mdx
@@ -5,9 +5,8 @@ You will need to install `nativewind` and it's peer dependencies `tailwindcss`, 
 <NPM
   deps={[
     "nativewind",
-    "tailwindcss",
-    "react-native-reanimated",
-    "react-native-safe-area-context",
+    "tailwindcss"
+  
   ]}
 />
 


### PR DESCRIPTION
Installing again reanimated gives the bellow error cause it's update the reanimated
[Reanimated] Mismatch between JavaScript part and native part of Reanimated (3.16.1 vs 3.10.1).
