### PR TITLE
fix: nativewind theme functions on web

### DIFF
--- a/.changeset/silly-crabs-grab.md
+++ b/.changeset/silly-crabs-grab.md
@@ -1,0 +1,5 @@
+---
+"nativewind": patch
+---
+
+fix: nativewind theme functions on web

--- a/packages/nativewind/src/theme.ts
+++ b/packages/nativewind/src/theme.ts
@@ -1,4 +1,4 @@
-const isNative = Boolean(process.env.NATIVEWIND_OS);
+import { isWeb } from "./tailwind/common";
 
 export const {
   hairlineWidth,
@@ -10,6 +10,6 @@ export const {
   roundToNearestPixel,
   platformColor,
   getPixelSizeForLayoutSize,
-} = isNative
-  ? require("react-native-css-interop/css-to-rn/functions")
-  : require("react-native-css-interop/css-to-rn/functions-web");
+} = isWeb
+  ? require("react-native-css-interop/css-to-rn/functions-web")
+  : require("react-native-css-interop/css-to-rn/functions");


### PR DESCRIPTION
Fixes #1160 and #1179

The `platformSelect` function when running on web is using the native version when `NATIVEWIND_OS` is set to `web`.

Using the #1160 example repo

Putting a `console.log(process.env.NATIVEWIND_OS)` in tailwind config is always printing `undefined` when building for web.
But logging to a file instead results in `web` being printed:

```ts
if (process.env.NATIVEWIND_OS !== undefined) {
  writeFileSync(file, process.env.NATIVEWIND_OS);
}
```

I tried adding test cases but couldn't get the  `NATIVEWIND_OS` environment variable to be set to undefined in the test case.