### PR TITLE
docs: fix box-content typo

### DIFF
--- a/apps/website/docs/tailwind/layout/box-sizing.mdx
+++ b/apps/website/docs/tailwind/layout/box-sizing.mdx
@@ -9,4 +9,4 @@ import Usage from "../_usage.mdx";
 
 ## Compatibility
 
-<Compatibility none={["box-border", "box-context"]} />
+<Compatibility none={["box-border", "box-content"]} />


### PR DESCRIPTION
Correct typo in box sizing class name `box-context` -> `box-content`

https://tailwindcss.com/docs/box-sizing