### PR TITLE
docs: Update Expo SDK babel config instruction

### DIFF
--- a/apps/website/docs/getting-started/_install.mdx
+++ b/apps/website/docs/getting-started/_install.mdx
@@ -1,6 +1,6 @@
 import NPM from "../_npm.mdx";
 
-You will need to install `nativewind` and it's peer dependencies `tailwindcss`, `react-native-reanimated` and `react-native-safe-area-context`
+You will need to install `nativewind` and its peer dependencies `tailwindcss`, `react-native-reanimated` and `react-native-safe-area-context`.
 
 <NPM
   deps={[
@@ -13,7 +13,7 @@ You will need to install `nativewind` and it's peer dependencies `tailwindcss`, 
 
 **Non-Expo projects**
 
-Run `pod-install` to finish installation of `react-native-reanimated`
+Run `pod-install` to finish installation of `react-native-reanimated`.
 
 ```bash
 npx pod-install

--- a/apps/website/docs/getting-started/_tailwind.mdx
+++ b/apps/website/docs/getting-started/_tailwind.mdx
@@ -15,7 +15,7 @@ module.exports = {
 }
 ```
 
-Create a CSS file and add the Tailwind directives
+Create a CSS file and add the Tailwind directives.
 
 ```css title="global.css"
 @tailwind base;
@@ -25,6 +25,6 @@ Create a CSS file and add the Tailwind directives
 
 :::info
 
-From here onwards, replace `./global.css` with the relative path to the CSS file you just created
+From here onwards, replace `./global.css` with the relative path to the CSS file you just created.
 
 :::

--- a/apps/website/docs/getting-started/expo-router.mdx
+++ b/apps/website/docs/getting-started/expo-router.mdx
@@ -18,6 +18,8 @@ import Tailwind from "./_tailwind.mdx";
 
 ### 3. Add the Babel preset
 
+Add the following configuration to your [`babel.config.js`](https://docs.expo.dev/versions/latest/config/babel/) file. If you are using Expo SDK 52 or above, generate this file by running `npx expo customize babel.config.js`.
+
 <Tabs>
   <TabItem value="SDK 50+">
     ```js title="babel.config.js"
@@ -54,7 +56,7 @@ import Tailwind from "./_tailwind.mdx";
 
 ### 4. Modify your metro.config.js
 
-If your project does not have a `metro.config.js` run `npx expo customize metro.config.js`
+If your project does not have a [`metro.config.js`](https://docs.expo.dev/guides/customizing-metro/) run `npx expo customize metro.config.js`.
 
 <Tabs>
 <TabItem value="SDK 50+">
@@ -86,7 +88,7 @@ module.exports = withNativeWind(config, { input: "./global.css" });
 
 ### 5. Import your CSS file
 
-```js title="app/_layout.js"
+```tsx title="app/_layout.tsx"
 import { Slot } from "expo-router";
 
 // Import your global CSS file


### PR DESCRIPTION
## Why

- Update babel.config.js modification step to:
  - Update step to add instructions to create this file when using Expo SDK 52
- Include links to Expo documentation for babel.config.js reference and metro.config.js customization guide
- Add missing period at the end of sentences
- Fix typo in step 1 for installation
- Update the code block language and file extension to use `.tsx` since Expo default template (since SDK 51) uses TypeScript by default