### PR TITLE
docs: Fix typos in multiple docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ It's worth noting that we do not have Github branches that directly correlate to
 # FAQ
 
 ## Is it safe to use v4?
-It's reasonably safe to use the `canary` version save for a known issue with styles being inconsistently applied. This issue is resolved in the `next` version; however, using this dist tag may break your app as it is considered experimental. To see which versions correlate to these dist tags, please refer to [our npm distrbution tags](https://github.com/nativewind/nativewind?tab=readme-ov-file#npm-distribution-tags).
+It's reasonably safe to use the `canary` version save for a known issue with styles being inconsistently applied. This issue is resolved in the `next` version; however, using this dist tag may break your app as it is considered experimental. To see which versions correlate to these dist tags, please refer to [our npm distribution tags](https://github.com/nativewind/nativewind?tab=readme-ov-file#npm-distribution-tags).
 
 ## Is NativeWind moving to Expo?
 
@@ -92,7 +92,7 @@ No. Expo is always exploring ways to handle styles better but NativeWind, as a p
 
 ## Can we disable the change that was done recently to auto-add nativewind types using a setting or something? I already have the settings using `compilerOptions.types`, so I would like to disable the file generation.
 
-Not at the moment. We've found this will cause a long term problem where people "forget" what their type config was doing. They then update their types and break the NativeWind ones. To combat this, we've copied the behavior from other major frameworks which is to handle their types seperately from user specified ones.
+Not at the moment. We've found this will cause a long term problem where people "forget" what their type config was doing. They then update their types and break the NativeWind ones. To combat this, we've copied the behavior from other major frameworks which is to handle their types separately from user specified ones.
 
 In the future, we may add an option like `dangerouslyDisableTypeScriptGeneration` or something verbose to prevent people from using it. We are tired of solving TypeScript issues, particularly ones such as "my types were working and now they aren't."
 

--- a/apps/website/docs/api/css-interop.mdx
+++ b/apps/website/docs/api/css-interop.mdx
@@ -4,7 +4,7 @@ This function "tags" components so that when its rendered, the runtime will know
 
 - You have a custom native component
 - You are using a third party component that needs the style prop to be resolved
-- You are using a thrid party component that does not pass all its props to its children
+- You are using a third party component that does not pass all its props to its children
 
 ## Usage
 

--- a/apps/website/docs/api/with-nativewind.mdx
+++ b/apps/website/docs/api/with-nativewind.mdx
@@ -16,7 +16,7 @@ module.exports = withNativeWind(config, {
 
 - `output`: The relative path to the output file. Defaults to `<projectRoot>/node_modules/.cache/nativewind/`
 - `projectRoot`: Abolsute path to your project root. Only used to set `output`
-- `inlineRem`: The numeric value used to inline the value of `rem` units on native. `false` will disable the behaviour. Defaults to `14`. [More infomation](../tailwind/typography/font-size.mdx)
+- `inlineRem`: The numeric value used to inline the value of `rem` units on native. `false` will disable the behaviour. Defaults to `14`. [More information](../tailwind/typography/font-size.mdx)
 - `configPath`: Relative path to your `tailwind.config` file. Defaults to `tailwind.config`. Recommended you use [`@config`](https://tailwindcss.com/docs/functions-and-directives#config) instead of this option.
 - `hotServerOptions`: Options to pass to the hot server. Defaults to `{ port: 8089 }`
 

--- a/apps/website/docs/core-concepts/dark-mode.mdx
+++ b/apps/website/docs/core-concepts/dark-mode.mdx
@@ -10,7 +10,7 @@ Expo apps do not follow the system appearance unless `userInterfaceStyle` is set
 
 ## Manual color scheme control
 
-To manualy control the color scheme you will need to enable the [`class` darkMode strategy](https://tailwindcss.com/docs/dark-mode#toggling-dark-mode-manually).
+To manually control the color scheme you will need to enable the [`class` darkMode strategy](https://tailwindcss.com/docs/dark-mode#toggling-dark-mode-manually).
 
 ```tsx title="tailwind.config.js"
 module.exports = {

--- a/apps/website/docs/core-concepts/style-specificity.mdx
+++ b/apps/website/docs/core-concepts/style-specificity.mdx
@@ -52,6 +52,6 @@ To address styling discrepancies across platforms, NativeWind allows the use of 
 
 // Remapped components (reusing the initial problem example)
 <MyText className="text-red-500" /> // Native: red, Web: black
-<MyText className="!text-red-500" /> // Both plaforms: red
+<MyText className="!text-red-500" /> // Both platforms: red
 
 ```

--- a/apps/website/docs/guides/editor-setup.md
+++ b/apps/website/docs/guides/editor-setup.md
@@ -4,9 +4,9 @@ Please refer to the [documentation on the Tailwind CSS website](https://tailwind
 
 ## Custom ClassName props
 
-`cssInterop`/`remapProps` allow you to create custom className props. You can follow the documentation of your choosen plugin to add this to the checked `classAttributes`.
+`cssInterop`/`remapProps` allow you to create custom className props. You can follow the documentation of your chosen plugin to add this to the checked `classAttributes`.
 
-Here's an example where we are using VS Code and custom component `cssInterop(Component, { headerClassName: 'headerStyle' })`: 
+Here's an example where we are using VS Code and custom component `cssInterop(Component, { headerClassName: 'headerStyle' })`:
 
 ```json
 {

--- a/apps/website/docs/tailwind/backgrounds/background-color.mdx
+++ b/apps/website/docs/tailwind/backgrounds/background-color.mdx
@@ -8,7 +8,7 @@ import Usage from "../_usage.mdx";
   none={["bg-inherit", "bg-current"]}
 />
 
-:::note backgrondOpacity (native only)
+:::note backgroundOpacity (native only)
 
 For performance reasons, NativeWind renders with the `corePlugin` `backgroundOpacity` disabled. This plugin allows text to dynamically change it's opacity via the `--tw-background-opacity` variable. Instead, the opacity is set as a static value in the `color` property.
 

--- a/apps/website/docs/tailwind/typography/font-size.mdx
+++ b/apps/website/docs/tailwind/typography/font-size.mdx
@@ -80,7 +80,7 @@ module.exports = withNativeWind({
 });
 ```
 
-You will then need to specifiy your own `rem` value in your CSS.
+You will then need to specify your own `rem` value in your CSS.
 
 ```css title="global.css"
 :root {

--- a/apps/website/docs/tailwind/typography/hyphens.mdx
+++ b/apps/website/docs/tailwind/typography/hyphens.mdx
@@ -1,7 +1,7 @@
 import Compatibility from "../_compatibility.mdx";
 import Usage from "../_usage.mdx";
 
-# Hypens
+# Hyphens
 
 ## Usage
 

--- a/apps/website/versioned_docs/version-v2/core-concepts/dark-mode.mdx
+++ b/apps/website/versioned_docs/version-v2/core-concepts/dark-mode.mdx
@@ -40,7 +40,7 @@ function App() {
 
 ### CSS
 
-To manualy toggle dark mode on web, you will need to enable the [`class` strategy](https://tailwindcss.com/docs/dark-mode#toggling-dark-mode-manually). This is all you need to do, we implement the logic to support both system preference and manual selection
+To manually toggle dark mode on web, you will need to enable the [`class` strategy](https://tailwindcss.com/docs/dark-mode#toggling-dark-mode-manually). This is all you need to do, we implement the logic to support both system preference and manual selection
 
 ```
 // tailwind.config.js

--- a/apps/website/versioned_docs/version-v2/overview/benchmarks.mdx
+++ b/apps/website/versioned_docs/version-v2/overview/benchmarks.mdx
@@ -6,6 +6,6 @@ This page is still under development, please do not use this data to reach any c
 
 :::
 
-These are micro benchmarks and should not be used to formulate opinions on real-world scenarios. They only demostrate how NativeWind performs under controlled scenarios. The benchmarks are run via GitHub Actions which is not a stable environment and greatly increases the variance.
+These are micro benchmarks and should not be used to formulate opinions on real-world scenarios. They only demonstrate how NativeWind performs under controlled scenarios. The benchmarks are run via GitHub Actions which is not a stable environment and greatly increases the variance.
 
 The benchmarks are [open-source](https://github.com/marklawlor/nativewind/tree/next/apps/benchmarks) and we highly encourage you fork them and test in a stable environment.

--- a/apps/website/versioned_docs/version-v2/quick-starts/expo.md
+++ b/apps/website/versioned_docs/version-v2/quick-starts/expo.md
@@ -60,7 +60,7 @@ module.exports = function (api) {
 
 ## Expo Web
 
-When running on web, NativeWind is a compatability layer between [Tailwind CSS](http://www.tailwindcss.com) and React Native.
+When running on web, NativeWind is a compatibility layer between [Tailwind CSS](http://www.tailwindcss.com) and React Native.
 
 You will need follow a [Tailwind CSS installation guide](https://tailwindcss.com/docs/installation) and ensure NativeWind is transpiled.
 

--- a/contributing.md
+++ b/contributing.md
@@ -10,7 +10,7 @@ Use this documentation and [this diagram](https://link.excalidraw.com/l/398AFcdY
 
 ## What can I contribute to?
 
-Before delving deeper into the collaboration worflow, let's talk about what kind of contributions can be made. Make sure you've reviewed the above diagram to understand how various aspects of NativeWind function.
+Before delving deeper into the collaboration workflow, let's talk about what kind of contributions can be made. Make sure you've reviewed the above diagram to understand how various aspects of NativeWind function.
 
 There are three main things you can usually contribute to:
 
@@ -39,7 +39,7 @@ When opening an issue, it's crucial to provide a reproduction of the problem to 
 #### Reproduction Templates
 
 - **StackBlitz template**: [NativeWind Test on StackBlitz](https://stackblitz.com/edit/nativewind-test?view=editor)
-- **Create Expo Stack template**: 
+- **Create Expo Stack template**:
   - `npx create-expo-stack@latest --nativewind`
   - `npx create-expo-stack@latest --nativewind --expo-router`
 


### PR DESCRIPTION
Found some typos while going through some of the pages in the docs. This PR is an attempt to fix them.