### PR TITLE
Fix typo

### DIFF
--- a/apps/website/docs/core-concepts/functions-and-directives.mdx
+++ b/apps/website/docs/core-concepts/functions-and-directives.mdx
@@ -60,7 +60,7 @@ Support for `calc()` is limited and will be improved in the future.
 }
 ```
 
-### Limtations
+### Limitations
 
 #### Mixing Units
 


### PR DESCRIPTION
Fixes a small typo in the functions-and-directives documentation.