### PR TITLE
fix: make `getCSSForPlatform` optional

### DIFF
--- a/packages/nativewind/src/metro/index.ts
+++ b/packages/nativewind/src/metro/index.ts
@@ -11,7 +11,7 @@ import { cssToReactNativeRuntimeOptions } from "./common";
 import { tailwindCli, tailwindConfig } from "./tailwind";
 import { setupTypeScript } from "./typescript";
 
-interface WithNativeWindOptions extends WithCssInteropOptions {
+interface WithNativeWindOptions extends Partial<WithCssInteropOptions> {
   input: string;
   projectRoot?: string;
   outputDir?: string;


### PR DESCRIPTION
The `WithCssInteropOptions` type has 2 required properties: `input` and `getCSSForPlatform`. However when using `withNativeWind`, only `input` is required at runtime. This PR makes all properties of `WithCssInteropOptions` optional when used as the `withNativeWind` options. `input` will be still required since it's overriden