### PR TITLE
Pressable should presist style function

### DIFF
--- a/packages/react-native-css-interop/src/runtime/web/api.ts
+++ b/packages/react-native-css-interop/src/runtime/web/api.ts
@@ -26,7 +26,7 @@ export const cssInterop: CssInterop = (baseComponent, mapping): any => {
     { ...props }: Record<string, any>,
     ref: any,
   ) {
-    if (props.cssInterop === false) {
+    if (props.cssInterop === false || typeof props.style === "function") {
       return createElement(baseComponent, props);
     }
 

--- a/packages/react-native-css-interop/src/runtime/wrap-jsx.ts
+++ b/packages/react-native-css-interop/src/runtime/wrap-jsx.ts
@@ -20,7 +20,7 @@ export default function wrapJSX(jsx: JSXFunction): JSXFunction {
 
     type = maybeHijackSafeAreaProvider(type);
 
-    // You can disable the css interop by setting `cssInterop` to false
+    // You can disable the css interop by setting `cssInterop` to false or pass the `style` prop as a function
     if (props && (props.cssInterop === false || props.style === "function")) {
       delete props.cssInterop;
     } else {

--- a/packages/react-native-css-interop/src/runtime/wrap-jsx.ts
+++ b/packages/react-native-css-interop/src/runtime/wrap-jsx.ts
@@ -21,7 +21,7 @@ export default function wrapJSX(jsx: JSXFunction): JSXFunction {
     type = maybeHijackSafeAreaProvider(type);
 
     // You can disable the css interop by setting `cssInterop` to false
-    if (props && props.cssInterop === false) {
+    if (props && (props.cssInterop === false || props.style === "function")) {
       delete props.cssInterop;
     } else {
       // Swap the component type with the interop version if it exists


### PR DESCRIPTION
I think we should not change the origin type of `Pressable`, which can support `StyleProps` or `function`. 
So that, I add some type check to prevent the `react-native-css-interop` changes `Pressable` when its style prop passes a function.