### PR TITLE
docs: fix more typo errors in docs

### DIFF
--- a/apps/website/docs/api/css-interop.mdx
+++ b/apps/website/docs/api/css-interop.mdx
@@ -4,7 +4,7 @@ This function "tags" components so that when its rendered, the runtime will know
 
 - You have a custom native component
 - You are using a third party component that needs the style prop to be resolved
-- You are using a thrid party component that does not pass all its props to its children
+- You are using a third party component that does not pass all its props to its children
 
 ## Usage
 

--- a/apps/website/docs/core-concepts/differences.md
+++ b/apps/website/docs/core-concepts/differences.md
@@ -37,6 +37,6 @@ React Native's `<Text />` renders with a `fontSize: 14`, while the web's default
 
 ## Color Opacity
 
-For performance reasons, NativeWind renders with the `corePlugins`: `textOpacity`,`borderOpacity`, `divideOpacity` and `backgroundOpacity` disabled. Theses plugin allows colors to dynamically changed via CSS variables. Instead, the opacity is set as a static value in the `color` property.
+For performance reasons, NativeWind renders with the `corePlugins`: `textOpacity`,`borderOpacity`, `divideOpacity` and `backgroundOpacity` disabled. These plugins allow colors to be dynamically changed via CSS variables. Instead, the opacity is set as a static value in the `color` property.
 
 If you require this functionality, you can enable the disabled plugins in your `tailwind.config.js` file.


### PR DESCRIPTION
Typo errors:

- thrid --> third
- Theses plugin --> These plugins