### PR TITLE
[docs] pin tailwindcss to ^3

### DIFF
--- a/apps/website/docs/getting-started/_install.mdx
+++ b/apps/website/docs/getting-started/_install.mdx
@@ -5,7 +5,7 @@ You will need to install `nativewind` and it's peer dependencies `tailwindcss`, 
 <NPM
   deps={[
     "nativewind",
-    "tailwindcss",
+    "tailwindcss@^3.0.0",
     "react-native-reanimated",
     "react-native-safe-area-context",
   ]}


### PR DESCRIPTION
Most recently when I was walking through the setup instructions (Expo Router, specifically), I got into a non-working state because it installed the latest `tailwindcss`, which was v.4. So, thought that pinning to v.3 could be helpful.