### PR TITLE
fix: tailwind version in the installation guide for tailwind v4

### DIFF
--- a/apps/website/docs/getting-started/_install.mdx
+++ b/apps/website/docs/getting-started/_install.mdx
@@ -5,7 +5,7 @@ You will need to install `nativewind` and it's peer dependencies `tailwindcss`, 
 <NPM
   deps={[
     "nativewind",
-    "tailwindcss",
+    "tailwindcss@3",
     "react-native-reanimated",
     "react-native-safe-area-context",
   ]}


### PR DESCRIPTION
# Overview
Tailwind v4 is released, and the approach is changed. Until finding a way to do this, we should declare v3 of Tailwind.

## Details
Recently, Tailwind changed its approach. Currently, the `@tailwindcss/cli` is always watching the changes in the project and print output with this command:
`npx @tailwindcss/cli -i ./src/input.css -o ./src/output.css --watch`

Nativewind approaches(especially Expo & React-Native methods) are incompatible. As a temporary solution,  developers should use **Tailwind V3**.


Refs:
* https://tailwindcss.com/docs/installation/tailwind-cli