### PR TITLE
Downgrade lightningcss to match @expo/metro-config

### DIFF
--- a/packages/react-native-css-interop/package.json
+++ b/packages/react-native-css-interop/package.json
@@ -56,7 +56,7 @@
     "@babel/traverse": "^7.23.0",
     "@babel/types": "^7.23.0",
     "debug": "^4.3.7",
-    "lightningcss": "^1.27.0",
+    "lightningcss": "~1.19.0",
     "semver": "^7.6.3"
   },
   "devDependencies": {


### PR DESCRIPTION
## What
Users are running into build issues with EAS due to a discrepancy in `lightningcss` versions between `react-native-css-interop` and `@expo/metro-config`. Likely due to a recent change on Expo's end. This downgrades our version from `^1.27.0` to `~1.19.0` to match what Expo has.