### PR TITLE
docs: set fixed tailwind version to last supported version

### DIFF
--- a/apps/website/docs/getting-started/_install.mdx
+++ b/apps/website/docs/getting-started/_install.mdx
@@ -6,7 +6,7 @@ You will need to install `nativewind` and it's peer dependencies `tailwindcss`, 
   framework={props.framework}
   deps={[
     "nativewind",
-    "tailwindcss",
+    "tailwindcss@3",
     props.framework === 'framework-less' ? 'react-native-reanimated' : 'react-native-reanimated@3.16.2',
     "react-native-safe-area-context",
   ]}


### PR DESCRIPTION
The actual nativewind installation guide is broken because it is installing tailwind@4, that is not supported yet.

So this PR update docs to recommend install tailwind@3 the last supported version, until nativewind starts support tailwind@4

![Screenshot 2025-02-20 at 22 47 12](https://github.com/user-attachments/assets/1147f030-dbec-4293-8d71-6e7a2fe4abf9)
