### PR TITLE
chore: fix install commands dependencies versions

### DIFF
--- a/apps/website/docs/getting-started/_install.mdx
+++ b/apps/website/docs/getting-started/_install.mdx
@@ -6,7 +6,7 @@ You will need to install `nativewind` and its peer dependencies `tailwindcss`, `
   framework={props.framework}
   deps={[
     "nativewind",
-    "tailwindcss@^3.4.17",
+    "tailwindcss@3.4.17",
     props.framework === 'framework-less' ? 'react-native-reanimated' : 'react-native-reanimated@3.16.2',
     "react-native-safe-area-context",
   ]}

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -14,7 +14,6 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
-    "@types/lodash.debounce": "4.0.8",
     "@docusaurus/core": "3.0.0",
     "@docusaurus/preset-classic": "3.0.0",
     "@mdx-js/react": "3.0.0",
@@ -26,6 +25,9 @@
     "react-twitter-embed": "4.0.4",
     "sass": "1.69.5",
     "tailwindcss": "3.4.4"
+  },
+  "devDependencies": {
+    "@types/lodash.debounce": "4.0.8"
   },
   "browserslist": {
     "production": [

--- a/apps/website/versioned_docs/version-v2/getting-started/_install.mdx
+++ b/apps/website/versioned_docs/version-v2/getting-started/_install.mdx
@@ -5,7 +5,7 @@ You will need to install `nativewind` and its peer dependency, `tailwindcss`.
 <NPM
   framework={props.framework}
   deps={[
-    "nativewind@^2.0.0",
+    "nativewind@2.0.0",
     "tailwindcss@3.3.2",
   ]}
 />


### PR DESCRIPTION
# Why

Version ranges are not supported in install commands, no matter of package manager used:

![Screenshot 2025-03-25 at 11 02 07](https://github.com/user-attachments/assets/4fa72a3e-a3f8-4f9a-b8a1-7256bae16eb6)
![Screenshot 2025-03-25 at 11 01 55](https://github.com/user-attachments/assets/76f040bd-50d2-4cbc-aedf-9e0a5d0cd65f)
![Screenshot 2025-03-25 at 11 03 51](https://github.com/user-attachments/assets/eb933e05-d299-43f4-8544-2619c62ca498)

# How

Correct invalid install commands in docs app, by dropping range indicators.