### PR TITLE
Add option 'customDeclarationPath' to NativeWind configuration and uptade docs

### DIFF
--- a/apps/website/docs/customization/configuration.md
+++ b/apps/website/docs/customization/configuration.md
@@ -53,3 +53,19 @@ The [environment used by browserslist & autoprefixer](https://github.com/browser
 Default: `{ port: <next-available> }`
 
 The options passed to `ws` for the development hot reloading server.
+
+### `customDeclarationPath`
+
+Type: `string | undefined`
+
+The path where the generated TypeScript declaration file `nativewind-env.d.ts` should be saved. This allows developers to specify a custom location for the declaration file
+
+**Example:**
+
+```javascript
+import { withNativeWind } from 'nativewind';
+
+const metroConfig = withNativeWind(config, {
+  input: 'src/styles.css',
+  customDeclarationPath: 'src/types/nativewind-env.d.ts',
+});

--- a/packages/nativewind/src/metro/index.ts
+++ b/packages/nativewind/src/metro/index.ts
@@ -21,6 +21,7 @@ interface WithNativeWindOptions extends WithCssInteropOptions {
   browserslistEnv?: string | null;
   typescriptEnvPath?: string;
   disableTypeScriptGeneration?: boolean;
+  customDeclarationPath?: string;
 }
 
 const debug = debugFn("nativewind");
@@ -35,6 +36,7 @@ export function withNativeWind(
     browserslistEnv = "native",
     typescriptEnvPath = "nativewind-env.d.ts",
     disableTypeScriptGeneration = false,
+    customDeclarationPath,
     ...options
   }: WithNativeWindOptions = {} as WithNativeWindOptions,
 ): MetroConfig {
@@ -50,8 +52,9 @@ export function withNativeWind(
 
   if (!disableTypeScriptGeneration) {
     debug(`checking TypeScript setup`);
-    setupTypeScript(typescriptEnvPath);
-  }
+    const declarationPath = customDeclarationPath || typescriptEnvPath;
+    setupTypeScript(declarationPath);
+  }  
 
   return withCssInterop(config, {
     ...cssToReactNativeRuntimeOptions,


### PR DESCRIPTION
The option 'customDeclarationPath' in NativeWind allows developers to specify where the TypeScript declaration file, nativewind-env.d.ts, should be generated. This flexibility helps keep projects organized by letting you place type definitions in a dedicated folder that fits your project's structure.

If you don’t set a custom path, the declaration file will still be created in the project root, ensuring that existing setups remain unaffected. This feature is especially useful for teams using TypeScript in React Native projects, as it enhances clarity and maintainability, making it easier to manage type definitions. Overall, it empowers developers to customize their workflow to better suit their needs.