### PR TITLE
docs: Add guides/examples.tsx page to showcase open source apps made using Nativewind

### DIFF
--- a/apps/website/docs/guides/examples.mdx
+++ b/apps/website/docs/guides/examples.mdx
@@ -1,0 +1,23 @@
+# Examples
+
+Here are some open-source apps and repositories using **NativeWind** in production or side projects. These examples can help you understand how to structure your code, how to use className conditionally, and how to work with third-party components.
+
+---
+
+## 🌄 [100Cims](https://github.com/expofast/100cims)
+
+<p align='center'>
+  <img src="https://i.imgur.com/UtFHXCj.png" alt="100cims"  />
+</p>
+
+Built using **Expo**, **Expo Router**, **NativeWind** and **Reanimated**, it includes features like:
+
+- Custom components, like Button, Input, Drawer... using NativeWind.
+- Dynamic theming (light/dark).
+- Animated layouts with parallax effect using react-native-reanimated.
+
+[Repository →](https://github.com/expofast/100cims)
+
+---
+
+Want to feature your project here? [Open a PR on GitHub](https://github.com/nativewind/nativewind)!


### PR DESCRIPTION
## Description

This merge request adds a new `.mdx` page under the NativeWind **guides** section to showcase open-source applications using NativeWind.

It introduces [100Cims](https://github.com/expofast/100cims), an open-source React Native app built with Expo and NativeWind.

Inspired by [react-native-paper showcase](https://callstack.github.io/react-native-paper/docs/showcase) page.

