### PR TITLE
Fix broken or outdated documentation link for installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Nativewind processes your styles during your application's build step and uses a
 
 ## Installation
 
-If you have an existing project, [use these guides](https://www.nativewind.dev/getting-started/installation) to configure Nativewind for your respective stack.
+If you have an existing project, [use these guides](https://www.nativewind.dev/docs/getting-started/installation) to configure Nativewind for your respective stack.
 
 Alternatively, you can create a new pre-configured project via our Quickstart below.
 


### PR DESCRIPTION
This PR fixes a broken link in the README.md under the Installation section.
 **What was fixed**
    Old link: https://www.nativewind.dev/getting-started/installation (broken)
    New link: https://www.nativewind.dev/docs/getting-started/installation (correct path)