### PR TITLE
Add missing animate-pulse to animation.mdx

### DIFF
--- a/apps/website/docs/tailwind/transitions-animation/animation.mdx
+++ b/apps/website/docs/tailwind/transitions-animation/animation.mdx
@@ -17,6 +17,7 @@ import AnimationWarning from "./_animation-warning.mdx";
     "animate-none",
     "animate-spin",
     "animate-ping",
+    "animate-pulse",
     "animate-bounce",
     "animate-[n]",
   ]}


### PR DESCRIPTION
Tested this out and pulse def works in Nativewind (4.1.4, with RN 0.74)
https://github.com/user-attachments/assets/d341d1cf-3e39-442f-86d4-794082024718

