### PR TITLE
fix: add runtime/components.js to sideeffects list

### DIFF
--- a/packages/react-native-css-interop/package.json
+++ b/packages/react-native-css-interop/package.json
@@ -4,7 +4,9 @@
   "description": "",
   "main": "dist/index",
   "types": "dist/index.d.ts",
-  "sideEffects": false,
+  "sideEffects": [
+    "dist/runtime/components.js"
+  ],
   "keywords": [
     "react-native",
     "react",


### PR DESCRIPTION
Since components is a file full of sideEffects it should be listed as such so that it can be correctly included in the bundle even if nothing is exported from it

#1509 