### PR TITLE
handle font-variant text style prop

### DIFF
--- a/.changeset/slick-points-notice.md
+++ b/.changeset/slick-points-notice.md
@@ -1,0 +1,5 @@
+---
+"react-native-css-interop": patch
+---
+
+handle font-variant text style prop

--- a/packages/react-native-css-interop/src/css-to-rn/index.ts
+++ b/packages/react-native-css-interop/src/css-to-rn/index.ts
@@ -5,7 +5,6 @@ import {
   Animation,
   ContainerRule,
   ContainerType,
-  Declaration,
   DeclarationBlock,
   EasingFunction,
   KeyframesRule,
@@ -29,6 +28,7 @@ import {
   AnimatableCSSProperty,
   AnimationFrame,
   CssToReactNativeRuntimeOptions,
+  Declaration,
   ExtractedAnimation,
   ExtractionWarning,
   ExtractRuleOptions,
@@ -232,7 +232,7 @@ export function cssToReactNativeRuntime(
  * @param {CssToReactNativeRuntimeOptions} parseOptions - Options for parsing the CSS code, such as grouping related rules together.
  */
 function extractRule(
-  rule: Rule | CSSInteropAtRule,
+  rule: Rule<Declaration> | CSSInteropAtRule,
   extractOptions: ExtractRuleOptions,
   partialStyle: Partial<StyleRule> = {},
 ) {
@@ -365,7 +365,7 @@ function extractCSSInteropFlag(
  * @returns undefined if no screen media queries are found in the mediaRule, else it returns the extracted styles.
  */
 function extractMedia(
-  mediaRule: MediaRule,
+  mediaRule: MediaRule<Declaration>,
   extractOptions: ExtractRuleOptions,
 ) {
   // Initialize an empty array to store screen media queries
@@ -404,7 +404,7 @@ function extractMedia(
  * @param parseOptions - The CssToReactNativeRuntimeOptions object to use when parsing styles.
  */
 function extractedContainer(
-  containerRule: ContainerRule,
+  containerRule: ContainerRule<Declaration>,
   extractOptions: ExtractRuleOptions,
 ) {
   // Iterate over all rules inside the containerRule and extract their styles using the updated ExtractRuleOptions

--- a/packages/react-native-css-interop/src/css-to-rn/parseDeclaration.ts
+++ b/packages/react-native-css-interop/src/css-to-rn/parseDeclaration.ts
@@ -10,7 +10,6 @@ import type {
   BoxShadow,
   ColorOrAuto,
   CssColor,
-  Declaration,
   DimensionPercentageFor_LengthValue,
   Display,
   EnvironmentVariable,
@@ -47,9 +46,11 @@ import type {
 
 import { isDescriptorArray } from "../shared";
 import type {
+  Declaration,
   ExtractionWarning,
   RuntimeFunction,
   RuntimeValueDescriptor,
+  FontVariant,
 } from "../types";
 import { FeatureFlagStatus } from "./feature-flags";
 import { toRNProperty } from "./normalize-selectors";
@@ -174,6 +175,7 @@ const validProperties = [
   "font-family",
   "font-size",
   "font-style",
+  "font-variant",
   "font-variant-caps",
   "font-weight",
   "gap",
@@ -1277,6 +1279,11 @@ export function parseDeclaration(
       return addStyleProp(
         declaration.property,
         parseFontStyle(declaration.value, parseOptions),
+      );
+    case "font-variant":
+      return addStyleProp(
+        declaration.property,
+        parseFontVariantCaps(declaration.value, parseOptions),
       );
     case "font-variant-caps":
       return addStyleProp(
@@ -2428,7 +2435,7 @@ function parseFontStyle(
 }
 
 function parseFontVariantCaps(
-  fontVariantCaps: FontVariantCaps,
+  fontVariantCaps: FontVariantCaps | FontVariant,
   options: ParseDeclarationOptionsWithValueWarning,
 ) {
   const allowed = new Set([

--- a/packages/react-native-css-interop/src/runtime/native/conditions.ts
+++ b/packages/react-native-css-interop/src/runtime/native/conditions.ts
@@ -2,7 +2,6 @@ import { I18nManager, PixelRatio, Platform } from "react-native";
 
 import type {
   ContainerCondition,
-  Declaration,
   MediaFeatureComparison,
   MediaFeatureValue,
   MediaQuery,
@@ -12,6 +11,7 @@ import type {
 import { DEFAULT_CONTAINER_NAME } from "../../shared";
 import {
   AttributeCondition,
+  Declaration,
   ExtractedContainerQuery,
   PseudoClassesQuery,
   StyleRule,

--- a/packages/react-native-css-interop/src/types.ts
+++ b/packages/react-native-css-interop/src/types.ts
@@ -12,7 +12,7 @@ import type {
   Animation,
   ContainerCondition,
   ContainerType,
-  Declaration,
+  Declaration as LightningcssDeclaration,
   EasingFunction,
   MediaQuery,
   SelectorComponent,
@@ -307,6 +307,22 @@ export type ExtractedContainer = {
   names?: string[] | false;
   type?: ContainerType;
 };
+
+export type FontVariant = 
+  | 'small-caps'
+  | 'oldstyle-nums'
+  | 'lining-nums'
+  | 'tabular-nums'
+  | 'proportional-nums';
+
+/**
+ * Handle fontVariant text style prop
+ */
+export type Declaration = LightningcssDeclaration | 
+  {
+    property: "font-variant";
+    value: FontVariant;
+  };
 
 export type ExtractedContainerQuery = {
   name?: string | null;


### PR DESCRIPTION
`font-variant` was not being handled. For example this: `<Text className="[font-variant:small-caps]">Hello!</Text>` was not actually using small-caps. But according to RN [docs](https://reactnative.dev/docs/0.79/text-style-props#fontvariant), `fontVariant` is a valid text style prop.

I tested this by using the following patch in my own repo, which uses nativewind:
```
diff --git a/dist/css-to-rn/parseDeclaration.js b/dist/css-to-rn/parseDeclaration.js
index 59ea66e459dbf6922bcd80a6ac014408ca13c2af..693fbae6cafc7d4a65033c95c00a3fd4a2a364f1 100644
--- a/dist/css-to-rn/parseDeclaration.js
+++ b/dist/css-to-rn/parseDeclaration.js
@@ -94,6 +94,7 @@ const validProperties = [
     "font-size",
     "font-style",
     "font-variant-caps",
+    "font-variant",
     "font-weight",
     "gap",
     "height",
@@ -761,6 +762,8 @@ function parseDeclaration(declaration, options) {
             return addStyleProp(declaration.property, parseFontStyle(declaration.value, parseOptions));
         case "font-variant-caps":
             return addStyleProp(declaration.property, parseFontVariantCaps(declaration.value, parseOptions));
+        case "font-variant":
+            return addStyleProp(declaration.property, parseFontVariantCaps(declaration.value, parseOptions));
         case "line-height":
             return addStyleProp(declaration.property, parseLineHeight(declaration.value, parseOptions));
         case "font":
```
Using this patch made `<Text className="[font-variant:small-caps]">Hello!</Text>` actually use small-caps.

I also added a `FontVariant` type. The css `font-variant` property allows much more values ([docs](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant)), but the RN `fontVariant` text style prop allows the values I listed in the type ([docs](https://reactnative.dev/docs/0.79/text-style-props#fontvariant)).
Either way as can be seen by the already existing `parseFontVariantCaps` function, these are the only values `react-native-css-interop` was allowing.