### PR TITLE
Return box shadow declaration

### DIFF
--- a/packages/react-native-css-interop/src/css-to-rn/parseDeclaration.ts
+++ b/packages/react-native-css-interop/src/css-to-rn/parseDeclaration.ts
@@ -1555,7 +1555,7 @@ export function parseDeclaration(
         parseTextAlign(declaration.value, parseOptions),
       );
     case "box-shadow": {
-      parseBoxShadow(declaration.value, parseOptions);
+      return parseBoxShadow(declaration.value, parseOptions);
     }
     case "aspect-ratio": {
       return addStyleProp(


### PR DESCRIPTION
Currently, the code is missing a return statement in the switch case of `parseDeclaration` which is causing the build to crash (on Android) when building and using a box-shadow class. Because of the missing return statement, the box-shadow is parsed as an aspect-ratio, which is causing the crash.

This simple PR should fix this bug.