### PR TITLE
Fixing type errors on V5 branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,9 @@ typings/
 # Yarn Integrity file
 .yarn-integrity
 
+# Yarn cache folder
+.yarn/
+
 # dotenv environment variables file
 .env
 .env.test

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "react-native": "0.80.1",
     "react-native-builder-bob": "^0.40.13",
     "react-native-css": "3.0.0-nightly.fa5e95b",
+    "react-native-css-interop": "^0.1.22",
     "react-native-reanimated": "4.0.1",
     "react-native-safe-area-context": "5.4.0",
     "react-native-worklets": "0.4.1",

--- a/src/__tests__/dark-mode.ios.tsx
+++ b/src/__tests__/dark-mode.ios.tsx
@@ -1,8 +1,11 @@
-import { Button, Text, View } from "react-native";
+import { Button, Text } from "react-native";
+import { View } from "react-native-css/components";
 
 import { act, fireEvent, screen } from "@testing-library/react-native";
 
-import { colorScheme, render, useColorScheme } from "../test-utils";
+import { colorScheme } from "react-native-css-interop";
+
+import { render, useColorScheme } from "../test-utils";
 
 const testID = "react-native-css-interop";
 
@@ -149,7 +152,8 @@ test("useColorScheme().setColorScheme() with darkMode: class", async () => {
         <Button
           testID={testIds.SYSTEM_BUTTON}
           title="System"
-          onPress={() => setColorScheme("system")}
+          // FIFME: System appears to be missing from the types - is this still meant to exist?
+          onPress={() => setColorScheme("system" as any)}
         />
       </View>
     );
@@ -203,9 +207,11 @@ test("useColorScheme().toggleColorScheme() with darkMode: class", async () => {
     );
   }
   await render(<UseColorScheme />, {
+    extraCss: `
+      @source inline("dark:text-red-500");
+    `,
     config: {
       darkMode: "class",
-      safelist: ["dark:text-red-500"],
     },
   });
 

--- a/src/__tests__/safe-area.test.ios.tsx
+++ b/src/__tests__/safe-area.test.ios.tsx
@@ -1,8 +1,8 @@
-import { ViewProps } from "react-native";
+import type { ViewProps } from "react-native";
 
-import { Metrics, SafeAreaProvider } from "react-native-safe-area-context";
+import { type Metrics, SafeAreaProvider } from "react-native-safe-area-context";
 
-import { INTERNAL_SET, native, renderCurrentTest } from "../test-utils";
+import { renderCurrentTest } from "../test-utils";
 
 const { vh } = native;
 

--- a/src/__tests__/safe-area.test.ios.tsx
+++ b/src/__tests__/safe-area.test.ios.tsx
@@ -2,7 +2,7 @@ import type { ViewProps } from "react-native";
 
 import { type Metrics, SafeAreaProvider } from "react-native-safe-area-context";
 
-import { renderCurrentTest } from "../test-utils";
+import { renderCurrentTest, native, INTERNAL_SET } from "../test-utils";
 
 const { vh } = native;
 

--- a/src/__tests__/states.tsx
+++ b/src/__tests__/states.tsx
@@ -1,7 +1,30 @@
 import { fireEvent, screen } from "@testing-library/react-native";
-import { Switch, TextInput, View } from "react-native-css/components";
+import { View } from "react-native-css/components";
 
 import { render } from "../test-utils";
+
+import { Switch as RNSwitch, TextInput as RNTextInput, type SwitchProps, type TextInputProps } from "react-native";
+
+import {
+  useCssElement,
+} from "react-native-css";
+import type { StyledConfiguration, StyledProps } from "react-native-css";
+
+const textInputMapping = {
+  className: "style",
+} satisfies StyledConfiguration<typeof RNTextInput>;
+
+function TextInput(props: StyledProps<TextInputProps, typeof textInputMapping>) {
+  return useCssElement(RNTextInput, props, textInputMapping);
+}
+
+const switchMapping = {
+  className: "style",
+} satisfies StyledConfiguration<typeof RNSwitch>;
+
+function Switch(props: StyledProps<SwitchProps, typeof switchMapping>) {
+  return useCssElement(RNSwitch, props, switchMapping);
+}
 
 const testID = "component";
 

--- a/src/__tests__/theme.tsx
+++ b/src/__tests__/theme.tsx
@@ -2,6 +2,7 @@ import { PixelRatio, Platform, PlatformColor, StyleSheet } from "react-native";
 
 import { screen } from "@testing-library/react-native";
 import { View } from "react-native-css/components";
+import {pixelScaleSelect, fontScaleSelect, roundToNearestPixel, getPixelSizeForLayoutSize, platformColor, platformSelect} from 'react-native-css-interop/css-to-rn/functions'
 
 import { render } from "../test-utils";
 

--- a/src/__tests__/transforms.tsx
+++ b/src/__tests__/transforms.tsx
@@ -205,7 +205,8 @@ describe("Transforms - Translate (%)", () => {
   test("translate-x-1/2", async () => {
     expect(
       await renderCurrentTest({
-        className: "w-2 translate-x-1/2",
+        // TODO: Check if this actually works
+        sourceInline: ["w-2 translate-x-1/2"],
       }),
     ).toStrictEqual({
       props: {
@@ -227,7 +228,7 @@ describe("Transforms - Translate (%)", () => {
   test("translate-y-1/2", async () => {
     expect(
       await renderCurrentTest({
-        className: "h-2 translate-y-1/2",
+        sourceInline: ["h-2 translate-y-1/2"],
       }),
     ).toStrictEqual({
       props: {
@@ -249,7 +250,7 @@ describe("Transforms - Translate (%)", () => {
   test("translate-x-full", async () => {
     expect(
       await renderCurrentTest({
-        className: "w-2 translate-x-full",
+        sourceInline: ["w-2 translate-x-full"],
       }),
     ).toStrictEqual({
       props: {
@@ -271,7 +272,7 @@ describe("Transforms - Translate (%)", () => {
   test("translate-y-full", async () => {
     expect(
       await renderCurrentTest({
-        className: "h-2 translate-y-full",
+        sourceInline: ["h-2 translate-y-full"],
       }),
     ).toStrictEqual({
       props: {
@@ -367,7 +368,7 @@ describe("Transforms - Mixed", () => {
   test("rotate-90 skew-y-1 translate-x-1", async () => {
     expect(
       await renderCurrentTest({
-        className: "rotate-90 skew-y-1 translate-x-1",
+        sourceInline: [ "rotate-90 skew-y-1 translate-x-1"],
       }),
     ).toStrictEqual({
       props: {

--- a/src/__tests__/transition-animations.tsx
+++ b/src/__tests__/transition-animations.tsx
@@ -1,6 +1,5 @@
 import { View } from "react-native-css/components";
 import { getAnimatedStyle } from "react-native-reanimated";
-import { opacity } from "react-native-reanimated/lib/typescript/reanimated2/Colors";
 
 import { render, screen } from "../test-utils";
 
@@ -17,9 +16,9 @@ test("transition-colors", async () => {
       className="transition-colors ease-linear bg-red-500 border-black"
     />,
     {
-      config: {
-        safelist: ["bg-blue-500 border-slate-500"],
-      },
+      extraCss: `
+        @source inline("bg-blue-500 border-slate-500");
+      `,
     },
   );
 
@@ -79,9 +78,9 @@ test("transition-opacity", async () => {
       className="transition-opacity ease-linear opacity-0"
     />,
     {
-      config: {
-        safelist: ["opacity-100"],
-      },
+      extraCss: `
+        @source inline("opacity-100");
+      `,
     },
   );
 
@@ -170,9 +169,9 @@ test("animate-pulse", async () => {
 
 test("changing animations", async () => {
   await render(<View testID={testID} className="animate-spin" />, {
-    config: {
-      safelist: ["animate-bounce"],
-    },
+    extraCss: `
+      @source inline("animate-bounce");
+    `,
   });
 
   let component = screen.getByTestId(testID);

--- a/src/__tests__/unofficial-plugins.test.ios.tsx
+++ b/src/__tests__/unofficial-plugins.test.ios.tsx
@@ -4,12 +4,12 @@
  * They are not officially supported by NativeWind
  */
 
-import { Text, View } from "react-native";
 
 import flattenColorPalette from "tailwindcss/lib/util/flattenColorPalette";
 import plugin from "tailwindcss/plugin";
 
 import { render, screen } from "../test-utils";
+import { Text, View } from "react-native-css/components";
 
 const testID = "nativewind";
 
@@ -117,7 +117,6 @@ test("text-shadow", async () => {
     },
     {
       theme: {
-        experimental: false,
         textShadowMultiplier: {
           DEFAULT: 1,
           sm: 4,

--- a/src/react-native-css.d.ts
+++ b/src/react-native-css.d.ts
@@ -1,0 +1,14 @@
+// TODO: Delete this when react=native-css is published
+declare module "react-native-css" {
+  export declare const styled;
+  export declare const setRem;
+  export declare const useCssElement;
+  export declare const useUnstableNativeVariable;
+  export type StyledConfiguration<T extends any> = any;
+  export type StyledProps<Props extends any, Mapping extends any> = any;
+};
+declare module "react-native-css/babel";
+declare module "react-native-css/metro" {
+  export declare const withReactNativeCSS: any;
+  export type WithReactNativeCSSOptions = any;
+}

--- a/src/react-native-css.d.ts
+++ b/src/react-native-css.d.ts
@@ -1,7 +1,0 @@
-// TODO: Delete this when react=native-css is published
-declare module "react-native-css";
-declare module "react-native-css/babel";
-declare module "react-native-css/metro" {
-  export declare const withReactNativeCSS: any;
-  export type WithReactNativeCSSOptions = any;
-}

--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -16,6 +16,7 @@ import {
 export * from "./index";
 
 export {
+  screen,
   native,
   INTERNAL_SET,
   type RenderOptions as InteropRenderOptions,

--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -7,6 +7,7 @@ import {
 import postcss from "postcss";
 import { View } from "react-native-css/components";
 import { registerCSS } from "react-native-css/jest";
+import type { Config } from "tailwindcss";
 
 export * from "./index";
 
@@ -27,6 +28,8 @@ export type NativewindRenderOptions = RenderOptions & {
   plugin?: boolean;
   /** Enable debug logging. @default false - Set process.env.NATIVEWIND_TEST_AUTO_DEBUG and run tests with the node inspector   */
   debug?: boolean;
+  /** Optional tailwindcss config */
+  config?: Config;
 };
 
 const debugDefault = Boolean(

--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -9,11 +9,21 @@ import { View } from "react-native-css/components";
 import { registerCSS } from "react-native-css/jest";
 import type { Config } from "tailwindcss";
 
+import {
+  type RenderOptions as InteropRenderOptions,
+} from "react-native-css-interop/test";
+
 export * from "./index";
+
+export {
+  native,
+  INTERNAL_SET,
+  type RenderOptions as InteropRenderOptions,
+} from "react-native-css-interop/test";
 
 const testID = "nativewind";
 
-export type NativewindRenderOptions = RenderOptions & {
+export type NativewindRenderOptions = RenderOptions & Pick<InteropRenderOptions, "cssOptions"> & {
   /** Replace the generated CSS*/
   css?: string;
   /** Appended after the generated CSS */

--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -13,6 +13,8 @@ import {
   type RenderOptions as InteropRenderOptions,
 } from "react-native-css-interop/test";
 
+type RenderResult = ReturnType<typeof tlRender> & ReturnType<typeof registerCSS>;
+
 export * from "./index";
 
 export {
@@ -60,7 +62,7 @@ export async function render(
     extraCss,
     ...options
   }: NativewindRenderOptions = {},
-) {
+): Promise<RenderResult> {
   if (!css) {
     css = ``;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -123,6 +123,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/generator@npm:^7.28.3":
+  version: 7.28.3
+  resolution: "@babel/generator@npm:7.28.3"
+  dependencies:
+    "@babel/parser": "npm:^7.28.3"
+    "@babel/types": "npm:^7.28.2"
+    "@jridgewell/gen-mapping": "npm:^0.3.12"
+    "@jridgewell/trace-mapping": "npm:^0.3.28"
+    jsesc: "npm:^3.0.2"
+  checksum: 10c0/0ff58bcf04f8803dcc29479b547b43b9b0b828ec1ee0668e92d79f9e90f388c28589056637c5ff2fd7bcf8d153c990d29c448d449d852bf9d1bc64753ca462bc
+  languageName: node
+  linkType: hard
+
 "@babel/helper-annotate-as-pure@npm:^7.27.1, @babel/helper-annotate-as-pure@npm:^7.27.3":
   version: 7.27.3
   resolution: "@babel/helper-annotate-as-pure@npm:7.27.3"
@@ -207,7 +220,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-module-imports@npm:^7.25.9, @babel/helper-module-imports@npm:^7.27.1":
+"@babel/helper-module-imports@npm:^7.22.15, @babel/helper-module-imports@npm:^7.25.9, @babel/helper-module-imports@npm:^7.27.1":
   version: 7.27.1
   resolution: "@babel/helper-module-imports@npm:7.27.1"
   dependencies:
@@ -344,6 +357,17 @@ __metadata:
   bin:
     parser: ./bin/babel-parser.js
   checksum: 10c0/c2ef81d598990fa949d1d388429df327420357cb5200271d0d0a2784f1e6d54afc8301eb8bdf96d8f6c77781e402da93c7dc07980fcc136ac5b9d5f1fce701b5
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.28.3":
+  version: 7.28.3
+  resolution: "@babel/parser@npm:7.28.3"
+  dependencies:
+    "@babel/types": "npm:^7.28.2"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 10c0/1f41eb82623b0ca0f94521b57f4790c6c457cd922b8e2597985b36bdec24114a9ccf54640286a760ceb60f11fe9102d192bf60477aee77f5d45f1029b9b72729
   languageName: node
   linkType: hard
 
@@ -1576,7 +1600,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.0.0, @babel/types@npm:^7.20.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.25.2, @babel/types@npm:^7.26.0, @babel/types@npm:^7.27.1, @babel/types@npm:^7.27.3, @babel/types@npm:^7.28.0, @babel/types@npm:^7.28.2, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4":
+"@babel/traverse@npm:^7.23.0":
+  version: 7.28.3
+  resolution: "@babel/traverse@npm:7.28.3"
+  dependencies:
+    "@babel/code-frame": "npm:^7.27.1"
+    "@babel/generator": "npm:^7.28.3"
+    "@babel/helper-globals": "npm:^7.28.0"
+    "@babel/parser": "npm:^7.28.3"
+    "@babel/template": "npm:^7.27.2"
+    "@babel/types": "npm:^7.28.2"
+    debug: "npm:^4.3.1"
+  checksum: 10c0/26e95b29a46925b7b41255e03185b7e65b2c4987e14bbee7bbf95867fb19c69181f301bbe1c7b201d4fe0cce6aa0cbea0282dad74b3a0fef3d9058f6c76fdcb3
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.0.0, @babel/types@npm:^7.20.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.23.0, @babel/types@npm:^7.25.2, @babel/types@npm:^7.26.0, @babel/types@npm:^7.27.1, @babel/types@npm:^7.27.3, @babel/types@npm:^7.28.0, @babel/types@npm:^7.28.2, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4":
   version: 7.28.2
   resolution: "@babel/types@npm:7.28.2"
   dependencies:
@@ -4270,7 +4309,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.3.5, debug@npm:^4.4.0, debug@npm:^4.4.1":
+"debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.3.5, debug@npm:^4.3.7, debug@npm:^4.4.0, debug@npm:^4.4.1":
   version: 4.4.1
   resolution: "debug@npm:4.4.1"
   dependencies:
@@ -6939,7 +6978,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lightningcss@npm:1.30.1":
+"lightningcss@npm:1.30.1, lightningcss@npm:^1.27.0":
   version: 1.30.1
   resolution: "lightningcss@npm:1.30.1"
   dependencies:
@@ -7694,6 +7733,7 @@ __metadata:
     react-native: "npm:0.80.1"
     react-native-builder-bob: "npm:^0.40.13"
     react-native-css: "npm:3.0.0-nightly.fa5e95b"
+    react-native-css-interop: "npm:^0.1.22"
     react-native-reanimated: "npm:4.0.1"
     react-native-safe-area-context: "npm:5.4.0"
     react-native-worklets: "npm:0.4.1"
@@ -8486,6 +8526,30 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"react-native-css-interop@npm:^0.1.22":
+  version: 0.1.22
+  resolution: "react-native-css-interop@npm:0.1.22"
+  dependencies:
+    "@babel/helper-module-imports": "npm:^7.22.15"
+    "@babel/traverse": "npm:^7.23.0"
+    "@babel/types": "npm:^7.23.0"
+    debug: "npm:^4.3.7"
+    lightningcss: "npm:^1.27.0"
+    semver: "npm:^7.6.3"
+  peerDependencies:
+    react: ">=18"
+    react-native: "*"
+    react-native-reanimated: ">=3.6.2"
+    tailwindcss: ~3
+  peerDependenciesMeta:
+    react-native-safe-area-context:
+      optional: true
+    react-native-svg:
+      optional: true
+  checksum: 10c0/d6052499b8615b58e02ee43b7d2906fd2b5ef90410c26af94dd11d6d93ed116ab0c96f7228573734030f1d41b4e8e2878a63b2223eb86c797730df207ed0c2f0
+  languageName: node
+  linkType: hard
+
 "react-native-css@npm:3.0.0-nightly.fa5e95b":
   version: 3.0.0-nightly.fa5e95b
   resolution: "react-native-css@npm:3.0.0-nightly.fa5e95b"
@@ -8975,7 +9039,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:7.7.2, semver@npm:^7.1.3, semver@npm:^7.3.5, semver@npm:^7.5.2, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.0":
+"semver@npm:7.7.2, semver@npm:^7.1.3, semver@npm:^7.3.5, semver@npm:^7.5.2, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.0, semver@npm:^7.6.3":
   version: 7.7.2
   resolution: "semver@npm:7.7.2"
   bin:


### PR DESCRIPTION
I just spent some time fixing the type errors on the V5 branch, so I figured that might be useful to you guys.

There's a few places where I've made best guesses on how to fix something.

In the states file (src\__tests__\states.tsx), I just made Switch and TextInput components based on usage I could see from react-native-css.
I'm assuming these already exist to you locally so you could probably remove that