### PR TITLE
[css-interop] Fixes for RN 0.81 and reanimated 4

### DIFF
--- a/packages/react-native-css-interop/babel.js
+++ b/packages/react-native-css-interop/babel.js
@@ -9,7 +9,8 @@ module.exports = function () {
           importSource: "react-native-css-interop",
         },
       ],
-      "react-native-reanimated/plugin",
+      // Use this plugin in reanimated 4 and later
+      "react-native-worklets/plugin",
     ],
   };
 };

--- a/packages/react-native-css-interop/src/runtime/native/render-component.tsx
+++ b/packages/react-native-css-interop/src/runtime/native/render-component.tsx
@@ -197,6 +197,9 @@ function createAnimatedComponent(Component: ComponentType<any>): any {
     return Component;
   }
 
+  // React.forwardRef is deprecated in React 19 and later, and in React Native 0.81 and later,
+  // this code will always throw an error. https://react.dev/reference/react/forwardRef
+  /*
   if (
     !(
       typeof Component !== "function" ||
@@ -207,6 +210,7 @@ function createAnimatedComponent(Component: ComponentType<any>): any {
       `Looks like you're passing an animation style to a function component \`${Component.name}\`. Please wrap your function component with \`React.forwardRef()\` or use a class component instead.`,
     );
   }
+  */
 
   const { default: Animated } =
     require("react-native-reanimated") as typeof import("react-native-reanimated");


### PR DESCRIPTION
These changes are needed to support React Native 0.81 and Reanimated 4 with the current version of Nativewind (v4).

See demo app at https://github.com/react-native-tvos/NativewindMultiplatform/tree/sdk-54-beta .

Reanimated 4 also requires a fix for this to work, see https://github.com/software-mansion/react-native-reanimated/pull/8099 .