### PR TITLE
[css-interop] Forward `props.ref` due to lost special `ref` semantics for React 19

### DIFF
--- a/packages/react-native-css-interop/src/runtime/native/api.ts
+++ b/packages/react-native-css-interop/src/runtime/native/api.ts
@@ -46,7 +46,7 @@ export const cssInterop: CssInterop = (baseComponent, mapping): any => {
    */
   if (type === "function") {
     component = (props: Record<string, any>) => {
-      return interop(baseComponent, configs, props, undefined);
+      return interop(baseComponent, configs, props, props.ref);
     };
   } else {
     component = forwardRef((props, ref) => {

--- a/packages/react-native-css-interop/src/runtime/native/api.ts
+++ b/packages/react-native-css-interop/src/runtime/native/api.ts
@@ -46,7 +46,7 @@ export const cssInterop: CssInterop = (baseComponent, mapping): any => {
    */
   if (type === "function") {
     component = (props: Record<string, any>) => {
-      return interop(baseComponent, configs, props, props.ref);
+      return interop(baseComponent, configs, props, undefined);
     };
   } else {
     component = forwardRef((props, ref) => {

--- a/packages/react-native-css-interop/src/runtime/native/native-interop.ts
+++ b/packages/react-native-css-interop/src/runtime/native/native-interop.ts
@@ -299,6 +299,10 @@ export function interop(
   sharedState.originalProps = originalProps;
   sharedState.initialRender = false;
 
+  // In React 19, ref semantics have changed and it's more like a regular prop now
+  // We should prevent it from being overridden as `undefined | null` here.
+  if (ref == null) ref = props.ref;
+
   return renderComponent(
     component,
     sharedState,


### PR DESCRIPTION
Resolves #1560

The issue affects any `ref` prop in React 19. In React 19 the semantics and application of the `ref` prop changes. Without patches, `react-native-css-interop` now loses `ref` props on some components in `react-native@0.81`.

It's unclear whether this may cause a regression in React 18. Testing needed. In theory it shouldn't since `props.ref` shouldn't be possible in React 18.

Related code: https://github.com/nativewind/nativewind/blob/ead6e7ed456aed032c66d45e3c91496df2a806a7/packages/react-native-css-interop/src/runtime/native/unwrap-components.ts#L6-L7