### PR TITLE
feat(nativewind): support postcss config in withNativeWind

### DIFF
--- a/.changeset/few-lobsters-jam.md
+++ b/.changeset/few-lobsters-jam.md
@@ -1,0 +1,7 @@
+---
+"nativewind": minor
+---
+
+Add `postcss` support to `withNativeWind` and forward it to Tailwind CLI (`--postcss`).
+
+This allows apps to opt in to project PostCSS config (or provide an explicit config path) when NativeWind compiles styles.

--- a/packages/nativewind/src/__tests__/metro-postcss-options.ts
+++ b/packages/nativewind/src/__tests__/metro-postcss-options.ts
@@ -1,0 +1,107 @@
+import path from "path";
+
+import { withCssInterop } from "react-native-css-interop/metro";
+
+import { withNativeWind } from "../metro";
+import { tailwindCli, tailwindConfig } from "../metro/tailwind";
+
+jest.mock("react-native-css-interop/metro", () => ({
+  withCssInterop: jest.fn((config) => config),
+}));
+
+jest.mock("../metro/tailwind", () => ({
+  tailwindCli: jest.fn(),
+  tailwindConfig: jest.fn(() => ({ important: false })),
+}));
+
+jest.mock("../metro/typescript", () => ({
+  setupTypeScript: jest.fn(),
+}));
+
+describe("withNativeWind postcss options", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("should resolve postcss path and pass to tailwind cli options", async () => {
+    const getCSSForPlatform = jest.fn().mockResolvedValue("/* css */");
+
+    (tailwindCli as jest.Mock).mockReturnValue({
+      getCSSForPlatform,
+    });
+
+    withNativeWind(
+      {} as any,
+      {
+        input: "./assets/style/global.css",
+        postcss: "./postcss.config.js",
+        disableTypeScriptGeneration: true,
+      } as any,
+    );
+
+    const options = (withCssInterop as jest.Mock).mock.calls[0][1];
+    await options.getCSSForPlatform("web", undefined);
+
+    expect(tailwindConfig).toHaveBeenCalled();
+    expect(getCSSForPlatform).toHaveBeenCalledWith(
+      expect.objectContaining({
+        platform: "web",
+        postcss: path.resolve("./postcss.config.js"),
+      }),
+    );
+  });
+
+  test("should pass boolean postcss option to tailwind cli options", async () => {
+    const getCSSForPlatform = jest.fn().mockResolvedValue("/* css */");
+
+    (tailwindCli as jest.Mock).mockReturnValue({
+      getCSSForPlatform,
+    });
+
+    withNativeWind(
+      {} as any,
+      {
+        input: "./assets/style/global.css",
+        postcss: true,
+        disableTypeScriptGeneration: true,
+      } as any,
+    );
+
+    const options = (withCssInterop as jest.Mock).mock.calls[0][1];
+    await options.getCSSForPlatform("android", undefined);
+
+    expect(getCSSForPlatform).toHaveBeenCalledWith(
+      expect.objectContaining({
+        platform: "android",
+        postcss: true,
+      }),
+    );
+  });
+
+  test("should not forward postcss=false as a string", async () => {
+    const getCSSForPlatform = jest.fn().mockResolvedValue("/* css */");
+
+    (tailwindCli as jest.Mock).mockReturnValue({
+      getCSSForPlatform,
+    });
+
+    withNativeWind(
+      {} as any,
+      {
+        input: "./assets/style/global.css",
+        postcss: false,
+        disableTypeScriptGeneration: true,
+      } as any,
+    );
+
+    const options = (withCssInterop as jest.Mock).mock.calls[0][1];
+    await options.getCSSForPlatform("android", undefined);
+
+    expect(getCSSForPlatform).toHaveBeenCalledWith(
+      expect.objectContaining({
+        platform: "android",
+        postcss: false,
+      }),
+    );
+  });
+});

--- a/packages/nativewind/src/__tests__/metro-tailwind-v3-postcss-env.ts
+++ b/packages/nativewind/src/__tests__/metro-tailwind-v3-postcss-env.ts
@@ -1,0 +1,70 @@
+import { EventEmitter } from "events";
+
+import { fork } from "child_process";
+
+import { tailwindCliV3 } from "../metro/tailwind/v3";
+
+jest.mock("child_process", () => ({
+  fork: jest.fn(),
+}));
+
+function mockForkAndResolveMessage() {
+  const child = new EventEmitter() as any;
+  child.stderr = new EventEmitter();
+  child.stdout = new EventEmitter();
+
+  (fork as jest.Mock).mockImplementation(() => {
+    setImmediate(() => {
+      child.emit("message", "/* css */");
+    });
+    return child;
+  });
+}
+
+describe("tailwindCliV3 postcss env forwarding", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("should pass true as NATIVEWIND_POSTCSS=true", async () => {
+    mockForkAndResolveMessage();
+
+    const cli = tailwindCliV3((() => undefined) as any);
+    await cli.getCSSForPlatform({
+      input: "./assets/style/global.css",
+      platform: "web",
+      postcss: true,
+    });
+
+    const forkOptions = (fork as jest.Mock).mock.calls[0][1];
+    expect(forkOptions.env.NATIVEWIND_POSTCSS).toBe("true");
+  });
+
+  test("should pass postcss path string as NATIVEWIND_POSTCSS", async () => {
+    mockForkAndResolveMessage();
+
+    const cli = tailwindCliV3((() => undefined) as any);
+    await cli.getCSSForPlatform({
+      input: "./assets/style/global.css",
+      platform: "ios",
+      postcss: "/tmp/postcss.config.js",
+    });
+
+    const forkOptions = (fork as jest.Mock).mock.calls[0][1];
+    expect(forkOptions.env.NATIVEWIND_POSTCSS).toBe("/tmp/postcss.config.js");
+  });
+
+  test("should not set NATIVEWIND_POSTCSS when postcss=false", async () => {
+    mockForkAndResolveMessage();
+
+    const cli = tailwindCliV3((() => undefined) as any);
+    await cli.getCSSForPlatform({
+      input: "./assets/style/global.css",
+      platform: "android",
+      postcss: false,
+    });
+
+    const forkOptions = (fork as jest.Mock).mock.calls[0][1];
+    expect(forkOptions.env.NATIVEWIND_POSTCSS).toBeUndefined();
+  });
+});

--- a/packages/nativewind/src/metro/index.ts
+++ b/packages/nativewind/src/metro/index.ts
@@ -17,6 +17,7 @@ interface WithNativeWindOptions extends WithCssInteropOptions {
   outputDir?: string;
   configPath?: string;
   cliCommand?: string;
+  postcss?: boolean | string;
   browserslist?: string | null;
   browserslistEnv?: string | null;
   typescriptEnvPath?: string;
@@ -31,6 +32,7 @@ export function withNativeWind(
     input,
     inlineRem = 14,
     configPath: tailwindConfigPath = "tailwind.config",
+    postcss = false,
     browserslist = "last 1 version",
     browserslistEnv = "native",
     typescriptEnvPath = "nativewind-env.d.ts",
@@ -39,6 +41,9 @@ export function withNativeWind(
   }: WithNativeWindOptions = {} as WithNativeWindOptions,
 ): MetroConfig {
   if (input) input = path.resolve(input);
+
+  const resolvedPostcss =
+    typeof postcss === "string" ? path.resolve(postcss) : postcss;
 
   debug(`input: ${input}`);
 
@@ -68,6 +73,7 @@ export function withNativeWind(
       return cli.getCSSForPlatform({
         platform,
         input,
+        postcss: resolvedPostcss,
         browserslist,
         browserslistEnv,
         onChange,

--- a/packages/nativewind/src/metro/tailwind/types.ts
+++ b/packages/nativewind/src/metro/tailwind/types.ts
@@ -3,6 +3,7 @@ import { GetCSSForPlatformOnChange } from "react-native-css-interop/metro";
 export interface TailwindCliOptions {
   input: string;
   platform: string;
+  postcss?: boolean | string;
   browserslist?: string | null;
   browserslistEnv?: string | null;
   onChange?: GetCSSForPlatformOnChange;

--- a/packages/nativewind/src/metro/tailwind/v3/child.ts
+++ b/packages/nativewind/src/metro/tailwind/v3/child.ts
@@ -53,6 +53,12 @@
     "--output": fakeOutput,
   };
 
+  if (process.env.NATIVEWIND_POSTCSS === "true") {
+    args["--postcss"] = true;
+  } else if (process.env.NATIVEWIND_POSTCSS) {
+    args["--postcss"] = process.env.NATIVEWIND_POSTCSS;
+  }
+
   if (process.env.NATIVEWIND_WATCH === "true") {
     args["--watch"] = true;
   }

--- a/packages/nativewind/src/metro/tailwind/v3/index.ts
+++ b/packages/nativewind/src/metro/tailwind/v3/index.ts
@@ -26,6 +26,12 @@ const getEnv = (options: TailwindCliOptions) => {
     NATIVEWIND_INPUT: options.input,
     NATIVEWIND_OS: options.platform,
     NATIVEWIND_WATCH: options.onChange ? "true" : "false",
+    NATIVEWIND_POSTCSS:
+      options.postcss === true
+        ? "true"
+        : typeof options.postcss === "string"
+          ? options.postcss
+          : undefined,
     BROWSERSLIST: options.browserslist ?? undefined,
     BROWSERSLIST_ENV: options.browserslistEnv ?? undefined,
   };


### PR DESCRIPTION
## Summary
This PR adds `postcss` support to `withNativeWind` and forwards it through the Tailwind v3 Metro pipeline, so native builds can opt into project `postcss.config.js`.

Closes #1704

## Changes
- Add `postcss?: boolean | string` to `withNativeWind` options.
- Resolve string `postcss` paths in `withNativeWind` before forwarding.
- Forward `postcss` into Tailwind CLI options.
- In Tailwind v3 env mapping:
  - `postcss: true` -> `NATIVEWIND_POSTCSS=true`
  - `postcss: "<path>"` -> `NATIVEWIND_POSTCSS=<path>`
  - `postcss: false | undefined` -> do not set `NATIVEWIND_POSTCSS`
- In child CLI process:
  - map `NATIVEWIND_POSTCSS` to `--postcss` flag/value.

## Tests
Added tests for:
- `withNativeWind` option forwarding:
  - string path resolution
  - `postcss: true`
  - `postcss: false` is not mis-forwarded
- v3 env forwarding:
  - `true` -> `"true"`
  - string path -> path value
  - `false` -> `undefined`

## Why
This enables Android/native responsive workflows where users need PostCSS transforms (e.g. `postcss-px-to-viewport-8-plugin`) applied before NativeWind consumes generated CSS.

## Release
Included changeset:
- `.changeset/few-lobsters-jam.md`
