### PR TITLE
test: add shadow-sm/md/lg/none tests

### DIFF
--- a/src/__tests__/shadow.tsx
+++ b/src/__tests__/shadow.tsx
@@ -1,6 +1,6 @@
-import { renderCurrentTest, renderSimple } from "../test-utils";
+import { renderCurrentTest } from "../test-utils";
 
-describe("Shadow utilities", () => {
+describe("Shadow", () => {
   test("shadow-sm", async () => {
     const result = await renderCurrentTest();
     expect(result.props.style.boxShadow).toStrictEqual([
@@ -42,7 +42,7 @@ describe("Shadow utilities", () => {
   });
 
   test("shadow-lg", async () => {
-    const result = await renderSimple({ className: "shadow-lg" });
+    const result = await renderCurrentTest();
     expect(result.props.style.boxShadow).toStrictEqual([
       {
         offsetX: 0,


### PR DESCRIPTION
## Summary

Adds validation tests for Tailwind CSS v4 shadow utilities through the full nativewind + react-native-css pipeline.

### Tests

- `shadow-sm` — verifies exact 2-shadow output with correct offsets, blur, spread, and color
- `shadow-md` — verifies exact 2-shadow output
- `shadow-lg` — verifies exact 2-shadow output
- `shadow-none` — verifies empty array

All tests use `renderCurrentTest()` and assertions use `toStrictEqual` with exact expected values to catch regressions precisely.

### Ring tests

Ring utilities (`ring-*`) depend on CSS `@property` support in react-native-css ([#277](https://github.com/nativewind/react-native-css/pull/277) + [#284](https://github.com/nativewind/react-native-css/pull/284)). I'll add ring validation tests in a follow-up once those land.
