### PR TITLE
fix: fix broken ./types export condition

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
       }
     },
     "./types": {
-      "typescript": "./types.d.ts"
+      "types": "./types.d.ts"
     },
     "./theme": "./theme.css"
   },

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="react-native-css/types" />


### PR DESCRIPTION
## Summary

The `"./types"` export in `package.json` is non-functional — it uses the wrong export condition and points to a missing file. This PR fixes both issues.

## Problem

`/// <reference types="nativewind/types" />` resolves to nothing:

```
TS2688: Cannot find type definition file for 'nativewind/types'.
```

Two issues:

1. **Wrong export condition** — `"typescript"` is not recognized by TypeScript's module resolution. Only `"types"`, `"default"`, `"import"`, and `"require"` are recognized.
2. **Missing file** — `types.d.ts` does not exist in the repo (it was removed during the monorepo refactor but the export was never updated).

This is the same pattern that was fixed for `"."` and `"./babel"` in #1638, but `"./types"` was missed.

## Solution

1. Fix the export condition: `"typescript"` → `"types"` (matching #1638)
2. Add the missing `types.d.ts` that re-exports className augmentations from `react-native-css/types`

The `types.d.ts` file is already listed in the `"files"` array, so npm will include it in future publishes automatically.

## Impact

- **Runtime:** Zero — types only
- **Build:** All quality gates pass (identical to `main`)
- **Consumers:** `/// <reference types="nativewind/types" />` correctly augments React Native components with `className` props

## Verification

All results identical to `main`:

- `yarn run typecheck` — PASS
- `yarn run lint` — 2 pre-existing errors (no new errors)
- `yarn run build` — PASS (CJS + ESM + DTS)
- `yarn run test` — PASS (4 suites, 18 tests)
- `yarn prettier --check package.json types.d.ts` — PASS
