### PR TITLE
fix: Appearance.setColorScheme(null) crash on RN 0.82+

### DIFF
--- a/packages/react-native-css-interop/src/__tests__/appearance.test.tsx
+++ b/packages/react-native-css-interop/src/__tests__/appearance.test.tsx
@@ -1,0 +1,53 @@
+import { Appearance, Platform } from "react-native";
+
+import { colorScheme } from "test";
+
+describe("colorScheme.set", () => {
+  let setColorSchemeSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    // Mock the implementation to avoid RN's built-in validation,
+    // which doesn't know about "unspecified" in older RN versions
+    setColorSchemeSpy = jest
+      .spyOn(Appearance, "setColorScheme")
+      .mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    setColorSchemeSpy.mockRestore();
+  });
+
+  test('passes "unspecified" to Appearance.setColorScheme on RN 0.82+', () => {
+    const original = Platform.constants.reactNativeVersion;
+    (Platform.constants as any).reactNativeVersion = { ...original, minor: 82 };
+
+    try {
+      colorScheme.set("system");
+      expect(setColorSchemeSpy).toHaveBeenCalledWith("unspecified");
+    } finally {
+      (Platform.constants as any).reactNativeVersion = original;
+    }
+  });
+
+  test("passes null to Appearance.setColorScheme on RN < 0.82", () => {
+    const original = Platform.constants.reactNativeVersion;
+    (Platform.constants as any).reactNativeVersion = { ...original, minor: 81 };
+
+    try {
+      colorScheme.set("system");
+      expect(setColorSchemeSpy).toHaveBeenCalledWith(null);
+    } finally {
+      (Platform.constants as any).reactNativeVersion = original;
+    }
+  });
+
+  test("passes value directly for light/dark", () => {
+    colorScheme.set("dark");
+    expect(setColorSchemeSpy).toHaveBeenCalledWith("dark");
+
+    setColorSchemeSpy.mockClear();
+
+    colorScheme.set("light");
+    expect(setColorSchemeSpy).toHaveBeenCalledWith("light");
+  });
+});

--- a/packages/react-native-css-interop/src/runtime/native/appearance-observables.ts
+++ b/packages/react-native-css-interop/src/runtime/native/appearance-observables.ts
@@ -3,6 +3,7 @@ import {
   Appearance,
   AppState,
   NativeEventSubscription,
+  Platform,
 } from "react-native";
 
 import { INTERNAL_RESET } from "../../shared";
@@ -22,7 +23,11 @@ const colorSchemeObservable = observable<"light" | "dark" | undefined>(
 export const colorScheme = {
   set(value: "light" | "dark" | "system") {
     if (value === "system") {
-      appearance.setColorScheme(null);
+      if ((Platform.constants?.reactNativeVersion?.minor ?? 0) >= 82) {
+        appearance.setColorScheme("unspecified" as any);
+      } else {
+        appearance.setColorScheme(null);
+      }
     } else {
       appearance.setColorScheme(value);
     }


### PR DESCRIPTION
## Summary

- Fixes #1722 — `Appearance.setColorScheme(null)` causes a `NullPointerException` on Android with React Native 0.82+ (Expo SDK 55)
- RN 0.82+ changed `ColorSchemeName` from `'light' | 'dark' | null` to `'light' | 'dark' | 'unspecified'` (non-nullable), so passing `null` crashes the native Kotlin `AppearanceModule`
- Version-gates the fix: uses `"unspecified"` on RN 0.82+, preserves `null` for older versions

## Test plan

- [x] Added `appearance.test.tsx` with tests for RN 0.82+ (`"unspecified"`), RN < 0.82 (`null`), and direct `"light"`/`"dark"` values
- [x] Existing `dark-mode.ios.tsx` tests pass (8/8)
- [x] Existing `media-query.test.tsx` tests pass (13/13)