### PR TITLE
fix: use repo prettier instead of creyD/prettier_action in CI

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -13,11 +13,11 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
 
-      - name: Setup Node.js 16.x
+      - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "20.x"
@@ -27,7 +27,5 @@ jobs:
       - name: Install Dependencies
         run: npm install
 
-      - name: Prettify code
-        uses: creyD/prettier_action@v4.3
-        with:
-          prettier_options: --write **/src/**/*.{ts,tsx}
+      - name: Check formatting
+        run: npx prettier --check '**/src/**/*.{ts,tsx}'


### PR DESCRIPTION
## Summary

- The `creyD/prettier_action@v4.3` bundles its own prettier version that crashes parsing several source files (`native-interop.ts`, `render-component.tsx`, `resolve-value.ts`, `react-native-safe-area-context.native.tsx`) with `TypeError: Cannot read properties of undefined (reading 'type')`
- This causes every PR to the v4 branch to fail the prettier check regardless of what files are changed
- Switches to running the repo's own prettier via `npx prettier --check` so the version from `package.json` is used
- Also updates `actions/checkout` from v3 to v4

## Test plan

- [x] The prettier CI step on this PR itself will validate the fix