### PR TITLE
fix: make CI green

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
 
+      - name: Build package
+        run: yarn build
+
       - name: Run unit tests
         run: yarn test --maxWorkers=2 --coverage
 

--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,10 @@ typings/
 # Yarn Integrity file
 .yarn-integrity
 
+# Yarn 4
+.yarn/cache/
+.yarn/install-state.gz
+
 # dotenv environment variables file
 .env
 .env.test

--- a/src/plugin.tsx
+++ b/src/plugin.tsx
@@ -7,19 +7,17 @@ function kebabCase(str: string) {
   );
 }
 
-const nativewind: PluginCreator = plugin.withOptions(
-  () =>
-    ({ matchVariant }) => {
-      matchVariant(
-        "@map",
-        (value = "", { modifier }) => {
-          value = kebabCase(value.replace(/&/, "\\&"));
+const nativewind: PluginCreator = plugin.withOptions(() => (api) => {
+  api.matchVariant(
+    "@map",
+    (value = "", { modifier }) => {
+      value = kebabCase(value.replace(/&/, "\\&"));
 
-          if (modifier) {
-            modifier = modifier.replace(/&/, "\\&");
-          }
+      if (modifier) {
+        modifier = modifier.replace(/&/, "\\&");
+      }
 
-          /**
+      /**
            Adding @media all is a hack for Tailwind CSS which has undocumented behavior
            If we do this `@nativeMapping { ...values } @slot;` it doesn't work, even if we
            wrap it like `& { @nativeMapping { ...values } @slot; }`
@@ -31,23 +29,22 @@ const nativewind: PluginCreator = plugin.withOptions(
            This does lead to weird looking CSS, but it works inside the browser and React Native
            */
 
-          if (modifier && value) {
-            // @nativeMapping-[value]/<modifier>:text-red-500
-            // In this instance, we are moving value (the style nativeMapping) to the modifier (the target key)
-            return `@nativeMapping { ${modifier}:${value} }; @media all`;
-          } else if (modifier && !value) {
-            // @nativeMapping/<modifier>:text-red-500
-            // In this instance, we are moving the last style value to the modifier
-            return `@nativeMapping ${modifier}; @media all`;
-          } else if (!modifier && value) {
-            return `@nativeMapping ${value}; @media all`;
-          } else {
-            return "";
-          }
-        },
-        { values: { DEFAULT: undefined } },
-      );
+      if (modifier && value) {
+        // @nativeMapping-[value]/<modifier>:text-red-500
+        // In this instance, we are moving value (the style nativeMapping) to the modifier (the target key)
+        return `@nativeMapping { ${modifier}:${value} }; @media all`;
+      } else if (modifier && !value) {
+        // @nativeMapping/<modifier>:text-red-500
+        // In this instance, we are moving the last style value to the modifier
+        return `@nativeMapping ${modifier}; @media all`;
+      } else if (!modifier && value) {
+        return `@nativeMapping ${value}; @media all`;
+      } else {
+        return "";
+      }
     },
-);
+    { values: { DEFAULT: undefined } },
+  );
+});
 
 export default nativewind;

--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -120,9 +120,11 @@ function getClassNames(
   }
 
   if (component.props.children) {
-    const children: ReactElement[] = Array.isArray(component.props.children)
-      ? component.props.children
-      : [component.props.children];
+    const children = (
+      Array.isArray(component.props.children)
+        ? component.props.children
+        : [component.props.children]
+    ) as ReactElement[];
 
     for (const child of children) {
       getClassNames(child as ReactElement<PropsWithChildren>, classNames);


### PR DESCRIPTION
## Summary

CI has been red on every push to `main` since October 2025. This fixes all four failure modes:

- **`.gitignore`** — add `.yarn/cache/` and `.yarn/install-state.gz` so the "Check for unstaged files" step stops failing after `yarn install`
- **CI workflow** — add `yarn build` before `yarn test` in the test job, since tests resolve through `package.json` exports pointing at `./dist/`
- **`plugin.tsx`** — stop destructuring `matchVariant` from the plugin API arg to fix `@typescript-eslint/unbound-method`
- **`test-utils.tsx`** — cast children array to fix `@typescript-eslint/no-unsafe-assignment`

## Impact

- **Runtime:** Zero — no behavioral changes
- **CI:** All jobs should pass (lint, test, build-library, build-web, build-ios-dev)