### PR TITLE
fix: fix build-ios-dev CI job

### DIFF
--- a/.github/actions/ios-dev-app/action.yml
+++ b/.github/actions/ios-dev-app/action.yml
@@ -4,6 +4,14 @@ description: Create IOS Development App
 runs:
   using: composite
   steps:
+    - name: Cache CocoaPods
+      uses: actions/cache@v4
+      with:
+        path: example/ios/Pods
+        key: pods-${{ runner.os }}-${{ hashFiles('example/ios/Podfile.lock') }}
+        restore-keys: |
+          pods-${{ runner.os }}-
+
     - name: Cache iOS development build
       id: ios-dev-cache
       uses: actions/cache@v4
@@ -37,9 +45,10 @@ runs:
       shell: bash
       run: yarn example expo prebuild --platform ios
 
-    - name: Install xcpretty
+    - name: Install CocoaPods dependencies
       shell: bash
-      run: gem install xcpretty
+      working-directory: example/ios
+      run: pod install
 
     - name: Build iOS development app
       id: build
@@ -57,7 +66,11 @@ runs:
           -sdk iphonesimulator \
           -derivedDataPath build/DerivedData \
           CODE_SIGNING_ALLOWED=NO \
-          build | xcpretty
+          build 2>&1 | tee /tmp/xcodebuild.log | xcpretty || {
+          echo "❌ xcodebuild failed. Raw output:"
+          cat /tmp/xcodebuild.log | grep -A 5 "error:"
+          exit 1
+        }
 
         cd ..
 


### PR DESCRIPTION
## Summary

The `build-ios-dev` CI job has never passed — it fails because `pod install` is never run. The committed `example/ios/` folder means `expo prebuild` reuses it and skips pod installation.

- Add explicit `pod install` step after `expo prebuild`
- Cache CocoaPods (`example/ios/Pods`) to avoid re-downloading on every run
- Remove unnecessary `gem install xcpretty` (pre-installed on GitHub macOS runners)
- Tee `xcodebuild` output through both `xcpretty` and a log file, so actual errors are visible on failure instead of being swallowed

## Impact

- **Runtime:** Zero — CI config only
- **CI:** `build-ios-dev` should finally pass