### PR TITLE
fix(ci): fix hashFiles failure in build-ios-dev

### DIFF
--- a/.github/actions/ios-dev-app/action.yml
+++ b/.github/actions/ios-dev-app/action.yml
@@ -18,7 +18,7 @@ runs:
       with:
         path: |
           example/ios/build/DerivedData
-        key: ios-dev-${{ runner.os }}-${{ hashFiles('example/ios/**', 'example/package.json', 'package.json') }}
+        key: ios-dev-${{ runner.os }}-${{ hashFiles('example/ios/Podfile.lock', 'example/package.json', 'package.json') }}
         restore-keys: |
           ios-dev-${{ runner.os }}-
 


### PR DESCRIPTION
## Summary
- `hashFiles('example/ios/**', ...)` fails because the `ios` directory has symlinks/partial state from the pods cache restore before `expo prebuild` runs
- Replaced with `hashFiles('example/ios/Podfile.lock', ...)` which is a better cache key — captures dependency changes without traversing the entire generated directory

## Test plan
- [ ] Verify `build-ios-dev` CI job passes on this PR