### PR TITLE
test: add ring and inset-ring utility validation tests

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -22,7 +22,7 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-native": "0.81.4",
-    "react-native-css": "3.0.0-preview.5",
+    "react-native-css": "^3.0.6",
     "react-native-reanimated": "~4.1.0",
     "react-native-web": "^0.21.0",
     "react-native-worklets": "~0.5.0",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "react": "19.1.0",
     "react-native": "0.81.4",
     "react-native-builder-bob": "^0.40.13",
-    "react-native-css": "^3.0.0",
+    "react-native-css": "^3.0.6",
     "react-native-reanimated": "~4.1.0",
     "react-native-safe-area-context": "5.6.1",
     "react-native-worklets": "~0.5.0",

--- a/src/__tests__/ring.tsx
+++ b/src/__tests__/ring.tsx
@@ -1,0 +1,151 @@
+import { renderCurrentTest, renderSimple } from "../test-utils";
+
+describe("Ring", () => {
+  test("ring-1", async () => {
+    const result = await renderCurrentTest();
+    expect(result.props.style.boxShadow).toStrictEqual([
+      {
+        offsetX: 0,
+        offsetY: 0,
+        blurRadius: 0,
+        spreadDistance: 1,
+        color: { semantic: ["label", "labelColor"] },
+      },
+    ]);
+  });
+
+  test("ring-2", async () => {
+    const result = await renderCurrentTest();
+    expect(result.props.style.boxShadow).toStrictEqual([
+      {
+        offsetX: 0,
+        offsetY: 0,
+        blurRadius: 0,
+        spreadDistance: 2,
+        color: { semantic: ["label", "labelColor"] },
+      },
+    ]);
+  });
+
+  test("ring-4", async () => {
+    const result = await renderCurrentTest();
+    expect(result.props.style.boxShadow).toStrictEqual([
+      {
+        offsetX: 0,
+        offsetY: 0,
+        blurRadius: 0,
+        spreadDistance: 4,
+        color: { semantic: ["label", "labelColor"] },
+      },
+    ]);
+  });
+
+  test("ring-0", async () => {
+    const result = await renderCurrentTest();
+    // ring-0 produces a zero-spread shadow with currentcolor (not transparent)
+    expect(result.props.style.boxShadow).toStrictEqual([
+      {
+        offsetX: 0,
+        offsetY: 0,
+        blurRadius: 0,
+        spreadDistance: 0,
+        color: { semantic: ["label", "labelColor"] },
+      },
+    ]);
+  });
+
+  test("shadow-sm ring-2", async () => {
+    const result = await renderSimple({ className: "shadow-sm ring-2" });
+    // Ring shadow + two drop shadows from shadow-sm
+    expect(result.props.style.boxShadow).toStrictEqual([
+      {
+        offsetX: 0,
+        offsetY: 0,
+        blurRadius: 0,
+        spreadDistance: 2,
+        color: { semantic: ["label", "labelColor"] },
+      },
+      {
+        offsetX: 0,
+        offsetY: 1,
+        blurRadius: 3,
+        spreadDistance: 0,
+        color: "#0000001a",
+      },
+      {
+        offsetX: 0,
+        offsetY: 1,
+        blurRadius: 2,
+        spreadDistance: -1,
+        color: "#0000001a",
+      },
+    ]);
+  });
+});
+
+describe("Inset Ring", () => {
+  test("inset-ring-1", async () => {
+    const result = await renderCurrentTest();
+    expect(result.props.style.boxShadow).toStrictEqual([
+      {
+        inset: true,
+        offsetX: 0,
+        offsetY: 0,
+        blurRadius: 0,
+        spreadDistance: 1,
+        color: { semantic: ["label", "labelColor"] },
+      },
+    ]);
+  });
+
+  test("inset-ring-2", async () => {
+    const result = await renderCurrentTest();
+    expect(result.props.style.boxShadow).toStrictEqual([
+      {
+        inset: true,
+        offsetX: 0,
+        offsetY: 0,
+        blurRadius: 0,
+        spreadDistance: 2,
+        color: { semantic: ["label", "labelColor"] },
+      },
+    ]);
+  });
+
+  test("inset-ring-0", async () => {
+    const result = await renderCurrentTest();
+    // inset-ring-0 produces a zero-spread inset shadow with currentcolor (not transparent)
+    expect(result.props.style.boxShadow).toStrictEqual([
+      {
+        inset: true,
+        offsetX: 0,
+        offsetY: 0,
+        blurRadius: 0,
+        spreadDistance: 0,
+        color: { semantic: ["label", "labelColor"] },
+      },
+    ]);
+  });
+
+  test("ring-2 inset-ring-2", async () => {
+    const result = await renderSimple({ className: "ring-2 inset-ring-2" });
+    // Inset ring first, then regular ring (Tailwind v4 box-shadow ordering)
+    expect(result.props.style.boxShadow).toStrictEqual([
+      {
+        inset: true,
+        offsetX: 0,
+        offsetY: 0,
+        blurRadius: 0,
+        spreadDistance: 2,
+        color: { semantic: ["label", "labelColor"] },
+      },
+      {
+        offsetX: 0,
+        offsetY: 0,
+        blurRadius: 0,
+        spreadDistance: 2,
+        color: { semantic: ["label", "labelColor"] },
+      },
+    ]);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -10070,7 +10070,7 @@ __metadata:
     react: "npm:19.1.0"
     react-native: "npm:0.81.4"
     react-native-builder-bob: "npm:^0.40.13"
-    react-native-css: "npm:^3.0.0"
+    react-native-css: "npm:^3.0.6"
     react-native-reanimated: "npm:~4.1.0"
     react-native-safe-area-context: "npm:5.6.1"
     react-native-worklets: "npm:~0.5.0"
@@ -11171,7 +11171,7 @@ __metadata:
     react-dom: "npm:19.1.0"
     react-native: "npm:0.81.4"
     react-native-builder-bob: "npm:^0.40.13"
-    react-native-css: "npm:3.0.0-preview.5"
+    react-native-css: "npm:^3.0.6"
     react-native-monorepo-config: "npm:^0.1.9"
     react-native-reanimated: "npm:~4.1.0"
     react-native-web: "npm:^0.21.0"
@@ -11180,26 +11180,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"react-native-css@npm:3.0.0-preview.5":
-  version: 3.0.0-preview.5
-  resolution: "react-native-css@npm:3.0.0-preview.5"
+"react-native-css@npm:^3.0.6":
+  version: 3.0.6
+  resolution: "react-native-css@npm:3.0.6"
   dependencies:
-    babel-plugin-react-compiler: "npm:^19.1.0-rc.2"
-    colorjs.io: "npm:0.6.0-alpha.1"
-    comment-json: "npm:^4.2.5"
-    debug: "npm:^4.4.1"
-  peerDependencies:
-    "@expo/metro-config": ">=54"
-    react: ">=19"
-    react-native: ">=0.81"
-  checksum: 10c0/5ff4f212db8d1182372cb703eb6d9abb3c4a0f26efa8db2be4d2ac6d299c95fa2944ce6167c2da6b6f3bf7db8e62306c7f3079ed569964c1db75ef1c277e4051
-  languageName: node
-  linkType: hard
-
-"react-native-css@npm:^3.0.0":
-  version: 3.0.1
-  resolution: "react-native-css@npm:3.0.1"
-  dependencies:
+    "@types/debug": "npm:^4.1.12"
     babel-plugin-react-compiler: "npm:^19.1.0-rc.2"
     colorjs.io: "npm:0.6.0-alpha.1"
     comment-json: "npm:^4.2.5"
@@ -11209,7 +11194,7 @@ __metadata:
     lightningcss: ">=1.27.0"
     react: ">=19"
     react-native: ">=0.81"
-  checksum: 10c0/61fd8bb657d68d1a901852b46d0e3b8778a634ea9451ff03eb0575d47a8f733be954f83c77cae3ef97bee89e423c2db8d85e493f203e6527cd1ca8e1775e2453
+  checksum: 10c0/51a35fad98f598d97e868c7d3b6d7a97937b9cd0db8568bb510120e83d2ca48ff28493eb532b4a3cb18b2173168312aee9370e262c42cec58bd408941ca6ad6e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Adds validation tests for Tailwind v4 `ring-*` and `inset-ring-*` utilities.

## Tests

### Ring

| Test | Utility | Validates |
|------|---------|-----------|
| `ring-1` | `ring-1` | `spreadDistance: 1`, `currentcolor` → PlatformColor |
| `ring-2` | `ring-2` | `spreadDistance: 2` |
| `ring-4` | `ring-4` | `spreadDistance: 4` |
| `ring-0` | `ring-0` | Zero-spread shadow (not transparent, not filtered) |
| `shadow-sm ring-2` | composition | Ring shadow first, then regular shadows |

### Inset Ring

| Test | Utility | Validates |
|------|---------|-----------|
| `inset-ring-1` | `inset-ring-1` | `inset: true`, `spreadDistance: 1`, PlatformColor |
| `inset-ring-2` | `inset-ring-2` | `inset: true`, `spreadDistance: 2` |
| `inset-ring-0` | `inset-ring-0` | `inset: true`, zero-spread (not filtered) |
| `ring-2 inset-ring-2` | composition | Inset ring first, then regular ring |

## Dependencies

Ring and inset-ring utilities go through the runtime shorthand path (due to `currentcolor`). These tests require `react-native-css >= 3.0.5` for the runtime box-shadow variable resolution fix ([#295](https://github.com/nativewind/react-native-css/pull/295)). The `package.json` range `^3.0.0` already allows this — should I include a `yarn up react-native-css` in this PR to update the lockfile, or would you prefer to handle that separately?

## Test plan

All assertions verified against `react-native-css@3.0.6` output. Follows exact patterns from `shadow.tsx` (`renderCurrentTest`, `renderSimple`, `toStrictEqual`).
