### PR TITLE
chore: update repo URLs to nativewind/nativewind

### DIFF
--- a/.changeset/update-repo-urls.md
+++ b/.changeset/update-repo-urls.md
@@ -1,0 +1,6 @@
+---
+"nativewind": patch
+"react-native-css-interop": patch
+---
+
+Update repository and bugs URLs from marklawlor/nativewind to nativewind/nativewind

--- a/packages/nativewind/package.json
+++ b/packages/nativewind/package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/marklawlor/nativewind.git"
+    "url": "git+https://github.com/nativewind/nativewind.git"
   },
   "author": {
     "name": "Mark Lawlor",
@@ -25,7 +25,7 @@
   },
   "homepage": "https://nativewind.dev",
   "bugs": {
-    "url": "https://github.com/marklawlor/nativewind/issues"
+    "url": "https://github.com/nativewind/nativewind/issues"
   },
   "engines": {
     "node": ">=16"

--- a/packages/react-native-css-interop/package.json
+++ b/packages/react-native-css-interop/package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/marklawlor/nativewind.git"
+    "url": "git+https://github.com/nativewind/nativewind.git"
   },
   "author": {
     "name": "Mark Lawlor",
@@ -25,7 +25,7 @@
   },
   "homepage": "https://nativewind.dev",
   "bugs": {
-    "url": "https://github.com/marklawlor/nativewind/issues"
+    "url": "https://github.com/nativewind/nativewind/issues"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
## Summary
- Update repository and bugs URLs in both `nativewind` and `react-native-css-interop` package.json files from `marklawlor/nativewind` to `nativewind/nativewind`
- The npm pages currently link to the old repo URL