### PR TITLE
fix: filter "unspecified" colorScheme during AppState transitions

### DIFF
--- a/packages/react-native-css-interop/src/__tests__/appearance.test.tsx
+++ b/packages/react-native-css-interop/src/__tests__/appearance.test.tsx
@@ -1,9 +1,8 @@
 import { Appearance, AppState, Platform } from "react-native";
 
 import { colorScheme } from "test";
-import {
-  systemColorScheme,
-} from "../runtime/native/appearance-observables";
+
+import { systemColorScheme } from "../runtime/native/appearance-observables";
 import { INTERNAL_RESET } from "../shared";
 
 describe("colorScheme.set", () => {
@@ -92,7 +91,10 @@ describe("appearance listener filters unspecified", () => {
     systemColorScheme.set("dark");
 
     // Simulate RN emitting "unspecified" during a transition
-    Object.defineProperty(AppState, "currentState", { value: "active", configurable: true });
+    Object.defineProperty(AppState, "currentState", {
+      value: "active",
+      configurable: true,
+    });
     appearanceCallback({ colorScheme: "unspecified" });
 
     // Should keep the previous value, not "unspecified"
@@ -119,7 +121,10 @@ describe("appearance listener filters unspecified", () => {
   test("passes through valid light/dark from Appearance listener", () => {
     systemColorScheme.set("light");
 
-    Object.defineProperty(AppState, "currentState", { value: "active", configurable: true });
+    Object.defineProperty(AppState, "currentState", {
+      value: "active",
+      configurable: true,
+    });
     appearanceCallback({ colorScheme: "dark" });
 
     expect(systemColorScheme.get()).toBe("dark");
@@ -139,12 +144,15 @@ describe("appearance listener filters unspecified", () => {
     getColorSchemeSpy.mockRestore();
   });
 
-  test("falls back to light when null and no previous scheme", () => {
-    Object.defineProperty(AppState, "currentState", { value: "active", configurable: true });
+  test("falls back to current scheme when null is received", () => {
+    systemColorScheme.set("light");
+
+    Object.defineProperty(AppState, "currentState", {
+      value: "active",
+      configurable: true,
+    });
     appearanceCallback({ colorScheme: null });
 
-    // null should resolve to the current systemColorScheme or "light"
-    const result = systemColorScheme.get();
-    expect(result === "light" || result === "dark").toBe(true);
+    expect(systemColorScheme.get()).toBe("light");
   });
 });

--- a/packages/react-native-css-interop/src/__tests__/appearance.test.tsx
+++ b/packages/react-native-css-interop/src/__tests__/appearance.test.tsx
@@ -1,6 +1,10 @@
-import { Appearance, Platform } from "react-native";
+import { Appearance, AppState, Platform } from "react-native";
 
 import { colorScheme } from "test";
+import {
+  systemColorScheme,
+} from "../runtime/native/appearance-observables";
+import { INTERNAL_RESET } from "../shared";
 
 describe("colorScheme.set", () => {
   let setColorSchemeSpy: jest.SpyInstance;
@@ -49,5 +53,98 @@ describe("colorScheme.set", () => {
 
     colorScheme.set("light");
     expect(setColorSchemeSpy).toHaveBeenCalledWith("light");
+  });
+});
+
+describe("appearance listener filters unspecified", () => {
+  let addChangeListenerSpy: jest.SpyInstance;
+  let addAppStateListenerSpy: jest.SpyInstance;
+  let appearanceCallback: (state: { colorScheme: string | null }) => void;
+  let appStateCallback: (state: string) => void;
+
+  beforeEach(() => {
+    // Capture the callbacks registered by resetAppearanceListeners
+    addChangeListenerSpy = jest
+      .spyOn(Appearance, "addChangeListener")
+      .mockImplementation((cb: any) => {
+        appearanceCallback = cb;
+        return { remove: jest.fn() } as any;
+      });
+
+    addAppStateListenerSpy = jest
+      .spyOn(AppState, "addEventListener")
+      .mockImplementation((_type: string, cb: any) => {
+        appStateCallback = cb;
+        return { remove: jest.fn() } as any;
+      });
+
+    // Reset to re-register listeners with our spies
+    colorScheme[INTERNAL_RESET](Appearance);
+  });
+
+  afterEach(() => {
+    addChangeListenerSpy.mockRestore();
+    addAppStateListenerSpy.mockRestore();
+  });
+
+  test('filters "unspecified" from Appearance change listener', () => {
+    // Set a known scheme first
+    systemColorScheme.set("dark");
+
+    // Simulate RN emitting "unspecified" during a transition
+    Object.defineProperty(AppState, "currentState", { value: "active", configurable: true });
+    appearanceCallback({ colorScheme: "unspecified" });
+
+    // Should keep the previous value, not "unspecified"
+    expect(systemColorScheme.get()).toBe("dark");
+  });
+
+  test('filters "unspecified" from AppState resume listener', () => {
+    // Set a known scheme first
+    systemColorScheme.set("dark");
+
+    // Simulate getColorScheme returning "unspecified" on resume
+    const getColorSchemeSpy = jest
+      .spyOn(Appearance, "getColorScheme")
+      .mockReturnValue("unspecified" as any);
+
+    appStateCallback("active");
+
+    // Should keep the previous value, not "unspecified"
+    expect(systemColorScheme.get()).toBe("dark");
+
+    getColorSchemeSpy.mockRestore();
+  });
+
+  test("passes through valid light/dark from Appearance listener", () => {
+    systemColorScheme.set("light");
+
+    Object.defineProperty(AppState, "currentState", { value: "active", configurable: true });
+    appearanceCallback({ colorScheme: "dark" });
+
+    expect(systemColorScheme.get()).toBe("dark");
+  });
+
+  test("passes through valid light/dark from AppState listener", () => {
+    systemColorScheme.set("light");
+
+    const getColorSchemeSpy = jest
+      .spyOn(Appearance, "getColorScheme")
+      .mockReturnValue("dark");
+
+    appStateCallback("active");
+
+    expect(systemColorScheme.get()).toBe("dark");
+
+    getColorSchemeSpy.mockRestore();
+  });
+
+  test("falls back to light when null and no previous scheme", () => {
+    Object.defineProperty(AppState, "currentState", { value: "active", configurable: true });
+    appearanceCallback({ colorScheme: null });
+
+    // null should resolve to the current systemColorScheme or "light"
+    const result = systemColorScheme.get();
+    expect(result === "light" || result === "dark").toBe(true);
   });
 });

--- a/packages/react-native-css-interop/src/__tests__/appearance.test.tsx
+++ b/packages/react-native-css-interop/src/__tests__/appearance.test.tsx
@@ -2,7 +2,6 @@ import { Appearance, AppState, Platform } from "react-native";
 
 import { colorScheme } from "test";
 
-import { systemColorScheme } from "../runtime/native/appearance-observables";
 import { INTERNAL_RESET } from "../shared";
 
 describe("colorScheme.set", () => {
@@ -61,6 +60,13 @@ describe("appearance listener filters unspecified", () => {
   let appearanceCallback: (state: { colorScheme: string | null }) => void;
   let appStateCallback: (state: string) => void;
 
+  const setCurrentAppState = (state: string) => {
+    Object.defineProperty(AppState, "currentState", {
+      value: state,
+      configurable: true,
+    });
+  };
+
   beforeEach(() => {
     // Capture the callbacks registered by resetAppearanceListeners
     addChangeListenerSpy = jest
@@ -87,72 +93,67 @@ describe("appearance listener filters unspecified", () => {
   });
 
   test('filters "unspecified" from Appearance change listener', () => {
-    // Set a known scheme first
-    systemColorScheme.set("dark");
+    // Set a known scheme first via the public listener path
+    setCurrentAppState("active");
+    appearanceCallback({ colorScheme: "dark" });
+    expect(colorScheme.get()).toBe("dark");
 
     // Simulate RN emitting "unspecified" during a transition
-    Object.defineProperty(AppState, "currentState", {
-      value: "active",
-      configurable: true,
-    });
     appearanceCallback({ colorScheme: "unspecified" });
 
     // Should keep the previous value, not "unspecified"
-    expect(systemColorScheme.get()).toBe("dark");
+    expect(colorScheme.get()).toBe("dark");
   });
 
   test('filters "unspecified" from AppState resume listener', () => {
-    // Set a known scheme first
-    systemColorScheme.set("dark");
-
-    // Simulate getColorScheme returning "unspecified" on resume
     const getColorSchemeSpy = jest
       .spyOn(Appearance, "getColorScheme")
-      .mockReturnValue("unspecified" as any);
+      .mockReturnValue("dark");
+
+    // Set a known scheme first via the public listener path
+    appStateCallback("active");
+    expect(colorScheme.get()).toBe("dark");
+
+    // Simulate getColorScheme returning "unspecified" on resume
+    getColorSchemeSpy.mockReturnValue("unspecified" as any);
 
     appStateCallback("active");
 
     // Should keep the previous value, not "unspecified"
-    expect(systemColorScheme.get()).toBe("dark");
+    expect(colorScheme.get()).toBe("dark");
 
     getColorSchemeSpy.mockRestore();
   });
 
   test("passes through valid light/dark from Appearance listener", () => {
-    systemColorScheme.set("light");
-
-    Object.defineProperty(AppState, "currentState", {
-      value: "active",
-      configurable: true,
-    });
+    setCurrentAppState("active");
+    appearanceCallback({ colorScheme: "light" });
     appearanceCallback({ colorScheme: "dark" });
 
-    expect(systemColorScheme.get()).toBe("dark");
+    expect(colorScheme.get()).toBe("dark");
   });
 
   test("passes through valid light/dark from AppState listener", () => {
-    systemColorScheme.set("light");
-
     const getColorSchemeSpy = jest
       .spyOn(Appearance, "getColorScheme")
-      .mockReturnValue("dark");
+      .mockReturnValue("light");
 
     appStateCallback("active");
 
-    expect(systemColorScheme.get()).toBe("dark");
+    getColorSchemeSpy.mockReturnValue("dark");
+
+    appStateCallback("active");
+
+    expect(colorScheme.get()).toBe("dark");
 
     getColorSchemeSpy.mockRestore();
   });
 
   test("falls back to current scheme when null is received", () => {
-    systemColorScheme.set("light");
-
-    Object.defineProperty(AppState, "currentState", {
-      value: "active",
-      configurable: true,
-    });
+    setCurrentAppState("active");
+    appearanceCallback({ colorScheme: "light" });
     appearanceCallback({ colorScheme: null });
 
-    expect(systemColorScheme.get()).toBe("light");
+    expect(colorScheme.get()).toBe("light");
   });
 });

--- a/packages/react-native-css-interop/src/runtime/native/appearance-observables.ts
+++ b/packages/react-native-css-interop/src/runtime/native/appearance-observables.ts
@@ -45,7 +45,8 @@ export const colorScheme = {
   },
   toggle() {
     let current = colorSchemeObservable.get();
-    if (current === undefined) current = appearance.getColorScheme() ?? "light";
+    if (current === undefined)
+      current = resolveColorScheme(appearance.getColorScheme());
     colorScheme.set(current === "light" ? "dark" : "light");
   },
   [INTERNAL_RESET]: (appearance: typeof Appearance) => {

--- a/packages/react-native-css-interop/src/runtime/native/appearance-observables.ts
+++ b/packages/react-native-css-interop/src/runtime/native/appearance-observables.ts
@@ -90,7 +90,18 @@ export function cssVariableObservable(
 
 /**
  * Appearance
+ *
+ * On RN 0.82+, Appearance can emit "unspecified" during AppState transitions
+ * (e.g. background→foreground). This is not a valid color scheme for consumers,
+ * so we filter it out and keep the last known valid scheme. (nativewind#1722)
  */
+function resolveColorScheme(
+  scheme: string | null | undefined,
+): "light" | "dark" {
+  if (scheme === "light" || scheme === "dark") return scheme;
+  return systemColorScheme.get() ?? "light";
+}
+
 let appearance = Appearance;
 let appearanceListener: NativeEventSubscription | undefined;
 let appStateListener: NativeEventSubscription | undefined;
@@ -105,14 +116,13 @@ function resetAppearanceListeners(
 
   appearanceListener = appearance.addChangeListener((state) => {
     if (AppState.currentState === "active") {
-      systemColorScheme.set(state.colorScheme ?? "light");
+      systemColorScheme.set(resolveColorScheme(state.colorScheme));
     }
   });
 
   appStateListener = appState.addEventListener("change", (type) => {
     if (type === "active") {
-      const colorScheme = appearance.getColorScheme() ?? "light";
-      systemColorScheme.set(colorScheme);
+      systemColorScheme.set(resolveColorScheme(appearance.getColorScheme()));
     }
   });
 }


### PR DESCRIPTION
## What

Fixes #1722

Fixes the follow-up bug reported in #1722 by @AlexPetrusca — `useColorScheme()` returns `"unspecified"` when the app resumes from background on RN 0.82+ (including 0.83 / Expo SDK 55).

## Why

On RN 0.82+, `Appearance.getColorScheme()` and the `Appearance` change listener can emit `"unspecified"` during `background→foreground` transitions. The previous `?? "light"` guard only catches `null`/`undefined`, not the truthy string `"unspecified"`, which leaks through `systemColorScheme` into `colorScheme.get()` and ultimately `useColorScheme()`.

### Reproduction steps (from @AlexPetrusca's report)

1. Set device theme to "dark"
2. Set app theme to "dark"  
3. Set app theme to "system"
4. Background the app
5. Foreground the app
6. `useColorScheme()` returns `"unspecified"` instead of `"dark"`

## How

Adds a `resolveColorScheme()` helper that strictly validates the scheme value — only `"light"` or `"dark"` pass through. Any other value (`"unspecified"`, `null`, `undefined`) falls back to the last known valid scheme from `systemColorScheme`. This is used in:

- `addChangeListener` callback
- `AppState` change callback
- `colorScheme.toggle()`

This approach is resilient to any future unexpected values from the RN Appearance API without requiring version-gating.

## Test

- [x] Added 5 new tests covering:
  - `"unspecified"` filtered from Appearance change listener
  - `"unspecified"` filtered from AppState resume listener  
  - Valid `"light"`/`"dark"` still pass through both listeners
  - `null` fallback behavior
- [x] All 3 existing `colorScheme.set` tests pass
- [x] All 13 `media-query.test.tsx` tests pass (no regressions)

## Environment

- react-native-css-interop: 0.2.3 (v4 branch)
- React Native: 0.82+ (including 0.83 / Expo SDK 55)
- Platforms: Android + iOS