### PR TITLE
fix: resolve tailwindcss from project context in monorepo setups

### DIFF
--- a/packages/nativewind/src/metro/index.ts
+++ b/packages/nativewind/src/metro/index.ts
@@ -30,6 +30,7 @@ export function withNativeWind(
   {
     input,
     inlineRem = 14,
+    projectRoot,
     configPath: tailwindConfigPath = "tailwind.config",
     browserslist = "last 1 version",
     browserslistEnv = "native",
@@ -42,7 +43,13 @@ export function withNativeWind(
 
   debug(`input: ${input}`);
 
-  const { important } = tailwindConfig(path.resolve(tailwindConfigPath));
+  // Resolve the Tailwind config path relative to projectRoot if provided,
+  // otherwise fall back to cwd. In monorepo setups, cwd is often the
+  // workspace root rather than the app directory where tailwind.config lives.
+  const resolvedConfigPath = projectRoot
+    ? path.resolve(projectRoot, tailwindConfigPath)
+    : path.resolve(tailwindConfigPath);
+  const { important } = tailwindConfig(resolvedConfigPath);
 
   debug(`important: ${important}`);
 

--- a/packages/nativewind/src/metro/tailwind/index.ts
+++ b/packages/nativewind/src/metro/tailwind/index.ts
@@ -1,22 +1,64 @@
 import { Debugger } from "debug";
-import tailwindPackage from "tailwindcss/package.json";
+import { createRequire } from "module";
 
 import { tailwindCliV3, tailwindConfigV3 } from "./v3";
 
-const isV3 = tailwindPackage.version.split(".")[0].includes("3");
+/**
+ * Resolve the Tailwind CSS version from the user's project context, not from
+ * NativeWind's own node_modules. In pnpm monorepos, NativeWind may have a
+ * nested copy of tailwindcss (potentially v4) which would cause a false
+ * version mismatch, even when the project itself has v3 installed correctly.
+ *
+ * We attempt resolution from the project root first (via `process.cwd()`),
+ * and fall back to NativeWind's own resolution if that fails.
+ */
+function getTailwindVersion(): string {
+  try {
+    // Try to resolve from the project's perspective first
+    const projectRequire = createRequire(
+      require.resolve("tailwindcss/package.json", {
+        paths: [process.cwd()],
+      }),
+    );
+    return projectRequire("tailwindcss/package.json").version;
+  } catch {
+    // Fall back to NativeWind's own resolution
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      return require("tailwindcss/package.json").version;
+    } catch {
+      return "unknown";
+    }
+  }
+}
+
+const tailwindVersion = getTailwindVersion();
+const isV3 = tailwindVersion.split(".")[0].includes("3");
 
 export function tailwindCli(debug: Debugger) {
   if (isV3) {
     return tailwindCliV3(debug);
   }
 
-  throw new Error("NativeWind only supports Tailwind CSS v3");
+  throw new Error(
+    `NativeWind only supports Tailwind CSS v3, but found v${tailwindVersion}. ` +
+      `In monorepo setups (e.g. pnpm workspaces), NativeWind may resolve a ` +
+      `different version of tailwindcss from its own node_modules. To fix ` +
+      `this, ensure tailwindcss@3.x is hoisted or add a package manager ` +
+      `override to force tailwindcss to v3.x across the workspace.`,
+  );
 }
 
 export function tailwindConfig(path: string) {
   if (isV3) {
     return tailwindConfigV3(path);
   } else {
-    throw new Error("NativeWind only supports Tailwind CSS v3");
+    throw new Error(
+      `NativeWind only supports Tailwind CSS v3, but found v${tailwindVersion}. ` +
+        `In monorepo setups (e.g. pnpm workspaces), NativeWind may resolve a ` +
+        `different version of tailwindcss from its own node_modules. To fix ` +
+        `this, ensure tailwindcss@3.x is hoisted or add a package manager ` +
+        `override to force tailwindcss to v3.x across the workspace.`,
+    );
   }
 }

--- a/packages/nativewind/src/metro/tailwind/v3/index.ts
+++ b/packages/nativewind/src/metro/tailwind/v3/index.ts
@@ -86,9 +86,30 @@ const flattenPresets = (configs: Partial<Config>[] = []): Partial<Config>[] => {
   ]);
 };
 
+/**
+ * Resolve tailwindcss/loadConfig from the user's project context first.
+ * In pnpm monorepos, NativeWind may have its own nested copy of tailwindcss
+ * (potentially v4) which does not export `loadConfig`, causing
+ * ERR_PACKAGE_PATH_NOT_EXPORTED errors even when the project has v3 installed.
+ */
+function resolveLoadConfig(): (path: string) => Config {
+  try {
+    // Try to resolve from the project's perspective first
+    const resolved = require.resolve("tailwindcss/loadConfig", {
+      paths: [process.cwd()],
+    });
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    return require(resolved);
+  } catch {
+    // Fall back to NativeWind's own resolution
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    return require("tailwindcss/loadConfig");
+  }
+}
+
 export function tailwindConfigV3(path: string) {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const config: Config = require("tailwindcss/loadConfig")(path);
+  const loadConfig = resolveLoadConfig();
+  const config: Config = loadConfig(path);
 
   const hasPreset = flattenPresets(config.presets).some((preset) => {
     return preset.nativewind;


### PR DESCRIPTION
In pnpm monorepos, NativeWind's own node_modules may contain a nested copy of tailwindcss (potentially v4) which differs from the version installed in the user's project. This causes three distinct failures:

1. Version check fails: The import of tailwindcss/package.json resolves from NativeWind's node_modules, detecting v4 and throwing 'NativeWind only supports Tailwind CSS v3' even when the project has v3 correctly installed.

2. loadConfig export missing: require('tailwindcss/loadConfig') resolves to the nested v4 copy which does not export this subpath, causing ERR_PACKAGE_PATH_NOT_EXPORTED errors.

3. Config path resolution: The default tailwind.config path is resolved relative to cwd, which in monorepo setups (where you run from the workspace root) points to the wrong directory.

This commit fixes all three issues:
- Uses require.resolve with paths:[process.cwd()] to resolve tailwindcss from the user's project context first, falling back to NativeWind's own resolution.
- Resolves configPath relative to projectRoot when provided.
- Improves error messages with actionable guidance for monorepo users.