### PR TITLE
fix(ci): drop explicit ref in prettier checkout to fix fork PRs

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -14,8 +14,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

The Prettier workflow used `ref: ${{ github.head_ref }}` to specify the branch to check out. For PRs from forks, that branch only exists on the fork, not on the base repo, so `git fetch` failed with exit code 1 on every fork PR.

This has been silently breaking CI on community PRs:
- #1767 ([failed run](https://github.com/nativewind/nativewind/actions/runs/25176066856/job/74701547737))
- #1527 (same root cause)

## Fix

Drop the explicit `ref:` and let `actions/checkout@v4` use its default behavior. On a `pull_request` event, that's `refs/pull/<n>/merge`, which GitHub maintains on the base repo and works for both branch PRs and fork PRs.

## Test plan

- [x] Once merged, re-run Prettier on PR #1767 and confirm checkout succeeds