### PR TITLE
fix: emit non-empty types for nativewind/preset

### DIFF
--- a/.changeset/famous-icons-hang.md
+++ b/.changeset/famous-icons-hang.md
@@ -1,0 +1,5 @@
+---
+"nativewind": patch
+---
+
+Fix empty TypeScript declarations for nativewind/preset

--- a/packages/nativewind/src/tailwind/index.ts
+++ b/packages/nativewind/src/tailwind/index.ts
@@ -1,4 +1,4 @@
-module.exports = Object.assign(
+const preset = Object.assign(
   () => {
     // Check if this file is being loaded by an editor with Tailwind CSS IntelliSense (e.g., VS Code).
     // If so, load the `native` part so that features implemented in `native` (like `p-safe`) can be auto-completed in the editor.
@@ -10,6 +10,8 @@ module.exports = Object.assign(
       : require("./native").default;
   },
   {
-    nativewind: true,
+    nativewind: true as const,
   },
 );
+
+export = preset;


### PR DESCRIPTION
## Summary

Fixes #1330.

`packages/nativewind/src/tailwind/index.ts` uses `module.exports = Object.assign(...)`, a pattern TypeScript's declaration emit can't handle — the published package ships an empty `dist/tailwind/index.d.ts`. Users importing `nativewind/preset` under `checkJs: true` (or from `*.ts` files) hit `TS2306: File '.../dist/tailwind/index.d.ts' is not a module`.

@danstepanov confirmed the root cause in [#1330 (comment)](https://github.com/nativewind/nativewind/issues/1330#issuecomment-4248968807):

> The published npm package has an empty (0 byte) `dist/tailwind/index.d.ts`. The source file (`src/tailwind/index.ts`) uses `module.exports = Object.assign(...)` which TypeScript's declaration emit can't generate types for.

## Fix

Switch to the canonical TS-compatible CJS pattern:

```ts
const preset = Object.assign(
  () => { /* ... */ },
  { nativewind: true as const },
);

export = preset;
```

- `tsc --declaration` emits a non-empty `.d.ts` for `export = X`.
- The compiled `.js` still emits `module.exports = preset` — identical runtime shape, no breaking change for consumers.
- `as const` narrows `nativewind: true` to a literal type, matching the manual workaround [users have been writing](https://github.com/nativewind/nativewind/issues/1330#issuecomment-2737061344) via module augmentation.

## Verification

**Before fix:** `dist/tailwind/index.d.ts` is 0 bytes.

**After fix:** `dist/tailwind/index.d.ts` contains:

```ts
declare const preset: (() => any) & {
    nativewind: true;
};
export = preset;
```

Compiled `dist/tailwind/index.js` is runtime-equivalent (`module.exports = preset` with the same callable + `nativewind: true` property).

## Tests

`npm test` passes — 784/784 tests across 30 suites, no regressions.