### PR TITLE
fix(release): skip recommended bump in release-it config

### DIFF
--- a/.config/release-it.config.ts
+++ b/.config/release-it.config.ts
@@ -9,6 +9,7 @@ export default {
   },
   plugins: {
     "@release-it/conventional-changelog": {
+      ignoreRecommendedBump: true,
       preset: {
         name: "conventionalcommits",
         types: [


### PR DESCRIPTION
## Summary

The v5 release workflow has been broken since [a6c4f64d](https://github.com/nativewind/nativewind/commit/a6c4f64d) introduced `@release-it/conventional-changelog`. The plugin's `recommendedBumpOpts.whatBump` doesn't match what `conventional-recommended-bump@10` expects against the `conventionalcommits` preset, and release-it crashes with:

\`\`\`
ERROR whatBump is not a function
\`\`\`

This was caught when I tried to cut a preview release after merging #1788 ([run 25943191472](https://github.com/nativewind/nativewind/actions/runs/25943191472)). The pin to `10.0.1` (intended to dodge the same bug from `10.0.2+`) doesn't avoid it.

Since [release.yml](.github/workflows/release.yml) always passes an explicit increment (`--preRelease=preview` or `--increment=<type>`), release-it doesn't need the plugin's bump recommendation. Setting \`ignoreRecommendedBump: true\` bypasses the broken path while keeping the CHANGELOG generation intact.

## Test plan

- [ ] Merge this PR
- [ ] Re-run the "Release & Publish to NPM" workflow with \`release-type=preview\`
- [ ] Confirm \`5.0.0-preview.4\` lands on npm under the \`preview\` dist-tag
- [ ] Confirm CHANGELOG.md picks up the new entry
- [ ] Confirm a GitHub Release is created with notes