### PR TITLE
fix(release): use whatBump:false to bypass broken preset loader

### DIFF
--- a/.config/release-it.config.ts
+++ b/.config/release-it.config.ts
@@ -9,7 +9,7 @@ export default {
   },
   plugins: {
     "@release-it/conventional-changelog": {
-      ignoreRecommendedBump: true,
+      whatBump: false,
       preset: {
         name: "conventionalcommits",
         types: [


### PR DESCRIPTION
## Summary

#1790 didn't actually fix the release. The pinned `@release-it/conventional-changelog@10.0.1` plugin has the same bug it always did: `getRecommendedVersion` calls `Bumper.bump(getWhatBump())`, and `getWhatBump` reads `bumperPreset.recommendedBumpOpts.whatBump` — but `conventional-changelog-conventionalcommits@8` no longer exposes that key, so it crashes with `whatBump is not a function`.

`ignoreRecommendedBump` only gates the `disablePlugin` lifecycle hook ([source](https://github.com/release-it/conventional-changelog/blob/10.0.1/index.js#L11-L13)) — it doesn't actually skip the broken bump call.

Reading the plugin source ([getWhatBump @ 10.0.1](https://github.com/release-it/conventional-changelog/blob/10.0.1/index.js#L44-L57)):

\`\`\`js
async function getWhatBump() {
  if (options.whatBump === false) {
    return () => ({ releaseType: null });
  } else if (typeof options.whatBump === 'function') {
    return options.whatBump;
  }
  const bumperPreset = await bumper.preset;
  if (bumperPreset === null) return () => ({ releaseType: null });
  return bumperPreset.whatBump || bumperPreset.recommendedBumpOpts.whatBump;
  //                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  //                                undefined.whatBump → TypeError
}
\`\`\`

Setting `whatBump: false` short-circuits to the stub at the top, which is the correct path for our setup: the workflow always passes an explicit `--increment=<type>` or `--preRelease=preview`, so we don't want the plugin to compute its own recommendation anyway.

Drops the no-op `ignoreRecommendedBump: true` from #1790.

## Test plan

- [ ] Merge this PR
- [ ] Re-run "Release & Publish to NPM" with `release-type=preview`
- [ ] Confirm `5.0.0-preview.4` lands on npm under `preview` dist-tag
- [ ] Confirm CHANGELOG.md picks up the new section
- [ ] Confirm a GitHub Release is created