### PR TITLE
[v4] fix(react-native-css-interop): Add metro-file-map forward compatibility

### DIFF
--- a/packages/react-native-css-interop/src/metro/index.ts
+++ b/packages/react-native-css-interop/src/metro/index.ts
@@ -1,6 +1,6 @@
+import assert from "assert";
 import fs from "fs";
 import fsPromise from "fs/promises";
-import assert from "assert";
 import path from "path";
 import type { EventEmitter } from "stream";
 
@@ -295,10 +295,7 @@ function getConfig(
   };
 }
 
-function emitHasteFileChange(
-  filePath: string,
-  debug: Debugger,
-) {
+function emitHasteFileChange(filePath: string, debug: Debugger) {
   assert(haste != null);
   // WARN: To prevent future incompatibilities with Metro from crashing, it's better
   // to just assume this call may fail
@@ -319,8 +316,8 @@ function emitHasteFileChange(
       // Post metro-file-map@0.83.6 / metro-file-map@0.84.3:
       // The internal change event structure has changed and expects a new shape now
       get rootDir() {
-        const rootDir = fileSystem?.lookup('');
-        assert(rootDir?.exists && typeof rootDir.realPath === 'string');
+        const rootDir = fileSystem?.lookup("");
+        assert(rootDir?.exists && typeof rootDir.realPath === "string");
         return rootDir.realPath;
       },
       changes: {
@@ -328,16 +325,11 @@ function emitHasteFileChange(
         removedDirectories: EMPTY_SET,
         addedFiles: EMPTY_SET,
         removedFiles: EMPTY_SET,
-        changedFiles: new Set([
-          [
-            filePath,
-            { isSymlink: false, modifiedTime }
-          ]
-        ]),
+        changedFiles: new Set([[filePath, { isSymlink: false, modifiedTime }]]),
       },
     });
   } catch (error) {
-    debug('virtualStyles.emit failed', error);
+    debug("virtualStyles.emit failed", error);
   }
 }
 

--- a/packages/react-native-css-interop/src/metro/index.ts
+++ b/packages/react-native-css-interop/src/metro/index.ts
@@ -1,6 +1,8 @@
 import fs from "fs";
 import fsPromise from "fs/promises";
+import assert from "assert";
 import path from "path";
+import type { EventEmitter } from "stream";
 
 import connect from "connect";
 import { debug as debugFn, Debugger } from "debug";
@@ -73,7 +75,11 @@ export type GetCSSForPlatform = (
 
 export type GetCSSForPlatformOnChange = (platform: string) => void;
 
-let haste: any;
+const EMPTY_SET = new Set<any>();
+
+let haste: unknown | undefined;
+let fileSystem: FileSystem | undefined;
+
 let virtualModulesPossible: undefined | Promise<void> = undefined;
 const virtualModules = new Map<string, Promise<string | Buffer>>();
 const outputDirectory = path.resolve(__dirname, "../../.cache");
@@ -228,7 +234,8 @@ function getConfig(
               .getDependencyGraph()
               .then(async (graph: any) => {
                 haste = graph._haste;
-                ensureFileSystemPatched(graph._fileSystem);
+                fileSystem = graph._fileSystem;
+                ensureFileSystemPatched(fileSystem!);
                 ensureBundlerPatched(bundler);
               });
 
@@ -288,6 +295,52 @@ function getConfig(
   };
 }
 
+function emitHasteFileChange(
+  filePath: string,
+  debug: Debugger,
+) {
+  assert(haste != null);
+  // WARN: To prevent future incompatibilities with Metro from crashing, it's better
+  // to just assume this call may fail
+  try {
+    const modifiedTime = Date.now();
+    (haste as EventEmitter).emit("change", {
+      eventsQueue: [
+        {
+          filePath,
+          metadata: {
+            modifiedTime: Date.now(),
+            size: 1, // Can be anything
+            type: "virtual", // Can be anything
+          },
+          type: "change",
+        },
+      ],
+      // Post metro-file-map@0.83.6 / metro-file-map@0.84.3:
+      // The internal change event structure has changed and expects a new shape now
+      get rootDir() {
+        const rootDir = fileSystem?.lookup('');
+        assert(rootDir?.exists && typeof rootDir.realPath === 'string');
+        return rootDir.realPath;
+      },
+      changes: {
+        addedDirectories: EMPTY_SET,
+        removedDirectories: EMPTY_SET,
+        addedFiles: EMPTY_SET,
+        removedFiles: EMPTY_SET,
+        changedFiles: new Set([
+          [
+            filePath,
+            { isSymlink: false, modifiedTime }
+          ]
+        ]),
+      },
+    });
+  } catch (error) {
+    debug('virtualStyles.emit failed', error);
+  }
+}
+
 async function startCSSProcessor(
   filePath: string,
   platform: string,
@@ -341,19 +394,7 @@ async function startCSSProcessor(
         );
 
         debug(`virtualStyles.emit ${platform}`);
-        haste.emit("change", {
-          eventsQueue: [
-            {
-              filePath,
-              metadata: {
-                modifiedTime: Date.now(),
-                size: 1, // Can be anything
-                type: "virtual", // Can be anything
-              },
-              type: "change",
-            },
-          ],
-        });
+        emitHasteFileChange(filePath, debug);
       }).then((css) => {
         debug(`virtualStyles.initial ${platform}`);
         return platform === "web"


### PR DESCRIPTION
## Summary

Starting from `metro-file-map@0.83.6` (Expo 55) / `metro-file-map@0.84.3` (Expo 56) the internal event structure in `metro-file-map` has changed and the `haste.emit` call may cause an error downstream. The structure we pass should be dual-compatible (forwards- and backwards-compatible)

The shape now expects a new structure, but we also have to pass the `rootDir`. I'd like to not assume the `config.projectRoot` exists, so to (a) get the exact shape that the event expects (normalised the exact same), and (b) guarantee that it exists, we can instead do a `fileSystem.lookup('')` call

> [!NOTE]
> I haven't yet been able to reproduce the exact error myself, so will have to ask someone who can to check this, but the old pattern is basically guaranteed to fail with new Metro versions.
>
> Built `react-native-css-interop/dist/metro/index.js` as per this branch for testing: https://gist.github.com/kitten/033600910e8d0c7c1c301c9689febca7

## Set of changes

- Add new properties to match new event shape
- Abstract event emitting and wrap in try-catch