### PR TITLE
Add changeset for v4.2.5 (react-native-css-interop metro-file-map forward compat)

### DIFF
--- a/.changeset/metro-file-map-forward-compat.md
+++ b/.changeset/metro-file-map-forward-compat.md
@@ -1,0 +1,5 @@
+---
+"react-native-css-interop": patch
+---
+
+Add metro-file-map forward compatibility


### PR DESCRIPTION
Adds a patch changeset for the unreleased #1795 fix (`react-native-css-interop` metro-file-map forward compatibility), which merged to `v4` without one.

`changeset status` confirms this releases **react-native-css-interop 0.2.5** and **nativewind 4.2.5** (the latter via the internal dependency + `updateInternalDependencies: patch`).

Merging this opens the changesets "Version Packages" PR; merging *that* is what publishes to npm.