### PR TITLE
fix(react-native-css-interop): emit modifiedFiles with a relative path for Metro 0.83+

### DIFF
--- a/.changeset/metro-haste-modifiedfiles.md
+++ b/.changeset/metro-haste-modifiedfiles.md
@@ -1,0 +1,7 @@
+---
+"react-native-css-interop": patch
+---
+
+Fix dev hot-reload of new utility classes on Metro 0.83+ (Expo SDK 55/56)
+
+The dev-mode haste "change" event now emits the `modifiedFiles` key (which Metro 0.83.6+ / 0.84.3+ reads) with a path relative to `rootDir`, instead of `changedFiles` with an absolute path. This stops the swallowed `modifiedFiles is not iterable` error and ensures the regenerated CSS virtual module is actually matched in Metro's graph and delivered to the connected client — so newly-added utility classes apply via Fast Refresh without a manual Metro restart.

--- a/packages/react-native-css-interop/src/metro/index.ts
+++ b/packages/react-native-css-interop/src/metro/index.ts
@@ -301,7 +301,25 @@ function emitHasteFileChange(filePath: string, debug: Debugger) {
   // to just assume this call may fail
   try {
     const modifiedTime = Date.now();
+
+    // Post metro-file-map@0.83.6 / metro-file-map@0.84.3:
+    // The internal change event structure changed. Metro reconstructs each
+    // changed file's absolute path via `path.join(rootDir, canonicalPath)` and
+    // iterates the `modifiedFiles` key (see DependencyGraph._onHasteChange and
+    // DeltaCalculator._handleMultipleFileChanges). So the change set must:
+    //   1. use `modifiedFiles` (not `changedFiles`), otherwise Metro spreads
+    //      `undefined` -> "modifiedFiles is not iterable"; and
+    //   2. carry the path RELATIVE to rootDir, not the absolute filePath -
+    //      `path.join(rootDir, "/abs/path")` yields a bogus path, so the virtual
+    //      module is never matched in the graph and the CSS update is never sent
+    //      to the connected client (new classes silently never apply).
+    const rootDirEntry = fileSystem?.lookup("");
+    assert(rootDirEntry?.exists && typeof rootDirEntry.realPath === "string");
+    const rootDir = rootDirEntry.realPath;
+    const canonicalPath = path.relative(rootDir, filePath);
+
     (haste as EventEmitter).emit("change", {
+      // Kept for compatibility with pre-0.83 Metro, which consumed eventsQueue.
       eventsQueue: [
         {
           filePath,
@@ -313,19 +331,15 @@ function emitHasteFileChange(filePath: string, debug: Debugger) {
           type: "change",
         },
       ],
-      // Post metro-file-map@0.83.6 / metro-file-map@0.84.3:
-      // The internal change event structure has changed and expects a new shape now
-      get rootDir() {
-        const rootDir = fileSystem?.lookup("");
-        assert(rootDir?.exists && typeof rootDir.realPath === "string");
-        return rootDir.realPath;
-      },
+      rootDir,
       changes: {
         addedDirectories: EMPTY_SET,
         removedDirectories: EMPTY_SET,
         addedFiles: EMPTY_SET,
         removedFiles: EMPTY_SET,
-        changedFiles: new Set([[filePath, { isSymlink: false, modifiedTime }]]),
+        modifiedFiles: new Set([
+          [canonicalPath, { isSymlink: false, modifiedTime }],
+        ]),
       },
     });
   } catch (error) {


### PR DESCRIPTION
> **A note from the author:** This PR addresses an issue that I found after multiple hours of debugging using claude opus 4.8. I can confirm that this change fixes the issue in my project. I let claude opus create this PR and write the description for it to help others. Please let me know if you need any more information, I'm happy to reply.

## Summary

In dev, NativeWind regenerates CSS on every save and notifies Metro by emitting a synthetic haste `"change"` event (`emitHasteFileChange`). On Expo SDK 55/56 (RN 0.83+, `metro` 0.83.6+ / `metro-file-map` 0.84.3+) the emitted payload is shaped incorrectly in two ways, so **newly-added utility classes never apply in dev until a full Metro restart** — pressing `r`/reload doesn't help either.

This is a follow-up to #1795, which introduced the new `changes` shape but used `changedFiles` and the absolute path.

## Root cause

Metro 0.83+ reads the `changes.modifiedFiles` key and reconstructs each changed file's absolute path via `path.join(rootDir, canonicalPath)` — in both `DependencyGraph._onHasteChange` and `DeltaBundler/DeltaCalculator._handleMultipleFileChanges`.

The current code emits:

```ts
changes: { /* ... */ changedFiles: new Set([[filePath /* absolute */, ...]]) }
```

which fails twice:

1. **Wrong key.** `changes.modifiedFiles` is `undefined`, so `_onHasteChange` does `[...changes.modifiedFiles]` → `TypeError: modifiedFiles is not iterable`. It's swallowed by the surrounding `try/catch` (no crash — only a `virtualStyles.emit failed` debug line), but `_onHasteChange` aborts before notifying the bundler. This is the error reported in #1773.
2. **Wrong path.** Even with the key fixed, `filePath` is absolute, so `path.join(rootDir, "/abs/.../ios.js")` produces a bogus path. The virtual CSS module is never matched in the graph, the delta never includes it, and the regenerated CSS is **never delivered to the connected client** — so the new class silently never applies, even after a reload.

## Fix

Emit `modifiedFiles` (the key Metro reads) with a path **relative to `rootDir`** (`path.relative(rootDir, filePath)`). `eventsQueue` is kept for pre-0.83 Metro.

## Validation

Reproduced and verified end-to-end on the iOS Simulator with **Expo SDK 55 / RN 0.83.6 / Metro 0.83.7 / react-native-css-interop 0.2.5**, using a probe component that logs its measured height via `onLayout`, with `DEBUG="nativewind*,react-native-css-interop*,Metro:DeltaCalculator"`:

- **Before:** editing a brand-new class (e.g. `h-[222px]`) logs `virtualStyles.emit failed TypeError: modifiedFiles is not iterable`; there is no `Handling change` for the CSS module; the class never applies — even after a manual reload.
- **After:** `Metro:DeltaCalculator Handling change: node_modules/react-native-css-interop/.cache/ios.js` → `Calculated graph delta {modified: 1}` → the class applies **live via Fast Refresh**, no restart. Verified across several consecutive brand-new arbitrary classes.

The same change-event contract (`modifiedFiles` + `path.join(rootDir, canonicalPath)`) applies to `metro` 0.84.x (Expo SDK 56); I validated on 0.83.7.

Refs #1773.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes [#1823](https://github.com/nativewind/nativewind/issues/1823)
