### PR TITLE
docs: link README banner to ronindevs.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<a href="https://nativewind.dev">
+<a href="https://ronindevs.com/?utm_source=nativewind&utm_medium=readme_banner">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="./.docs/img/banner-dark.jpg" />
     <source media="(prefers-color-scheme: light)" srcset="./.docs/img/banner-light.jpg" />


### PR DESCRIPTION
The README banner displays ronindevs.com ("No masters, just mastery.") but the link around it still pointed to nativewind.dev. This points the banner at https://ronindevs.com instead, with UTM params (`utm_source=nativewind&utm_medium=readme_banner`) so visits from the README are attributable.

One-line change, docs only.