### PR TITLE
feat: add Switch thumb-* and track-* color utilities

### DIFF
--- a/src/__tests__/switch.tsx
+++ b/src/__tests__/switch.tsx
@@ -1,0 +1,21 @@
+import { renderCurrentTest } from "../test-utils";
+
+describe("Custom - Switch thumbColor", () => {
+  test("thumb-black", async () => {
+    expect(await renderCurrentTest()).toStrictEqual({
+      props: {
+        style: { thumbColor: "#000" },
+      },
+    });
+  });
+});
+
+describe("Custom - Switch trackColor", () => {
+  test("track-black", async () => {
+    expect(await renderCurrentTest()).toStrictEqual({
+      props: {
+        style: { trackColor: "#000" },
+      },
+    });
+  });
+});

--- a/theme.css
+++ b/theme.css
@@ -42,6 +42,16 @@
   @prop -rn-tint tint;
 }
 
+@utility thumb-* {
+  -rn-thumb-color: --value(--color-*);
+  @prop -rn-thumb-color thumbColor;
+}
+
+@utility track-* {
+  -rn-track-color: --value(--color-*);
+  @prop -rn-track-color trackColor;
+}
+
 @utility ripple-* {
   -rn-ripple-style: --value("borderless");
   -rn-ripple-color: --value(--color-*);


### PR DESCRIPTION
## What

Adds two custom utilities to `theme.css`:

- `thumb-*` maps a color to the React Native Switch `thumbColor` prop
- `track-*` maps a color to the React Native Switch `trackColor` prop

Both follow the same `@prop` pattern as the existing `tint-*` utility, reading the value from `--color-*`.

## Why

Fixes #1757. v4 provided `thumb-*` utilities and track color values for styling the Switch component, and these were not listed in the migration guide as intentionally removed. This restores that behavior in v5. The mapping approach (color to `thumbColor` / `trackColor` via `@prop`) matches what was suggested in the issue.

## Tests

Added `src/__tests__/switch.tsx` covering `thumb-black` and `track-black`, following the existing test conventions. The full suite passes:

```
Test Suites: 8 passed, 8 total
Tests:       37 passed, 37 total
```
