### PR TITLE
feat: add caret-* utility for cursorColor

### DIFF
--- a/src/__tests__/caret.tsx
+++ b/src/__tests__/caret.tsx
@@ -1,0 +1,12 @@
+import { renderCurrentTest } from "../test-utils";
+
+describe("Custom - TextInput cursorColor", () => {
+  test("caret-black", async () => {
+    expect(await renderCurrentTest()).toStrictEqual({
+      props: {
+        cursorColor: "#000",
+        style: {},
+      },
+    });
+  });
+});

--- a/theme.css
+++ b/theme.css
@@ -42,6 +42,10 @@
   @prop -rn-tint tint;
 }
 
+@utility caret-* {
+  caret-color: --value(--color-*);
+}
+
 @utility ripple-* {
   -rn-ripple-style: --value("borderless");
   -rn-ripple-color: --value(--color-*);


### PR DESCRIPTION
## What

Adds a `caret-*` color utility so `caret-black`, `caret-red-500`, etc. set the `cursorColor` prop on `TextInput` again.

Closes #1756

## Why

In v4, Nativewind mapped `caret-*` to the `cursorColor` prop. v5 dropped that mapping and it was not listed in the migration guide as an intentional removal, so the utilities silently stopped working.

## How

```css
@utility caret-* {
  caret-color: --value(--color-*);
}
```

react-native-css already maps the standard CSS `caret-color` property to the `cursorColor` prop (see the default mapping in `parsePropAtRule`, `compiler/atRules.js`), so emitting `caret-color` restores the v4 behavior cleanly. I placed it next to the existing `tint-*` utility to keep the RN-specific color utilities together.

A note on approach: the issue suggested wiring this up with `@prop`. I tried the form that mirrors `tint-*` (`-rn-cursor: --value(--color-*); @prop -rn-cursor cursorColor;`), but because `caret-color -> cursorColor` is already a built-in mapping, the custom `-rn-cursor` declaration also leaked through as a `cursor` entry in `style`, producing a duplicate value. Using the standard `caret-color` property goes through the same mapping mechanism without the leak. Happy to switch to an explicit `@prop` mapping if you prefer that style.

## Test

Added `src/__tests__/caret.tsx`, following the existing test conventions:

```ts
test("caret-black", async () => {
  expect(await renderCurrentTest()).toStrictEqual({
    props: {
      cursorColor: "#000",
      style: {},
    },
  });
});
```

Full suite is green locally (`yarn jest`: 8 suites, 36 tests passing). `yarn typecheck` passes.
