### PR TITLE
Harden automated issue repro evidence capture

### DIFF
--- a/.github/scripts/capture-agent-device.sh
+++ b/.github/scripts/capture-agent-device.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+platform="$1"
+app_target="$2"
+artifact_path="${3:-}"
+evidence_dir="${4:-evidence/$platform}"
+
+mkdir -p "$evidence_dir"
+touch "$evidence_dir/agent-device.log"
+commands_file="$evidence_dir/commands.jsonl"
+: > "$commands_file"
+
+record() {
+  local name="$1"
+  local exit_code="$2"
+  local started_at="$3"
+  local artifact="${4:-}"
+  local ended_at duration_ms size
+
+  ended_at="$(date +%s)"
+  duration_ms=$(( (ended_at - started_at) * 1000 ))
+  size="null"
+  if [ -n "$artifact" ] && [ -f "$artifact" ]; then
+    size="$(wc -c < "$artifact" | tr -d ' ')"
+  fi
+
+  printf '{"name":"%s","exitCode":%d,"durationMs":%d,"artifact":"%s","artifactBytes":%s}\n' \
+    "$name" "$exit_code" "$duration_ms" "$artifact" "$size" >> "$commands_file"
+}
+
+run_cmd() {
+  local name="$1"
+  shift
+  local started_at exit_code
+
+  started_at="$(date +%s)"
+  "$@" 2>> "$evidence_dir/agent-device.log"
+  exit_code=$?
+  record "$name" "$exit_code" "$started_at"
+  return 0
+}
+
+run_to_file() {
+  local name="$1"
+  local artifact="$2"
+  shift 2
+  local started_at exit_code
+
+  started_at="$(date +%s)"
+  "$@" > "$artifact" 2>> "$evidence_dir/agent-device.log"
+  exit_code=$?
+  record "$name" "$exit_code" "$started_at" "$artifact"
+  return 0
+}
+
+run_artifact_cmd() {
+  local name="$1"
+  local artifact="$2"
+  shift 2
+  local started_at exit_code
+
+  started_at="$(date +%s)"
+  "$@" 2>> "$evidence_dir/agent-device.log"
+  exit_code=$?
+  record "$name" "$exit_code" "$started_at" "$artifact"
+  return 0
+}
+
+agent-device --version > "$evidence_dir/agent-device-version.txt" 2>> "$evidence_dir/agent-device.log" || true
+
+if [ -n "$artifact_path" ]; then
+  run_cmd install agent-device install "$app_target" "$artifact_path" --platform "$platform"
+fi
+
+if [ "$platform" = "ios" ]; then
+  run_cmd prepare-ios-runner agent-device prepare ios-runner --platform ios --timeout 240000
+fi
+
+run_cmd open-save-script agent-device open "$app_target" --platform "$platform" --save-script "$evidence_dir/launch.ad"
+run_cmd logs-clear agent-device logs clear --restart --platform "$platform"
+
+if [ "$platform" = "ios" ]; then
+  run_cmd open-relaunch agent-device open "$app_target" --platform ios --relaunch --launch-console "$evidence_dir/app.console.log"
+else
+  run_cmd open-relaunch agent-device open "$app_target" --platform "$platform" --relaunch
+fi
+
+run_cmd wait-startup agent-device wait 25000 --platform "$platform"
+run_artifact_cmd screenshot "$evidence_dir/screen.png" agent-device screenshot "$evidence_dir/screen.png" --platform "$platform"
+run_to_file perf "$evidence_dir/perf.json" agent-device perf --json --platform "$platform"
+run_to_file snapshot "$evidence_dir/snapshot.txt" agent-device snapshot --platform "$platform"
+run_to_file snapshot-interactive "$evidence_dir/snapshot-interactive.txt" agent-device snapshot -i --platform "$platform"
+run_to_file logs-path "$evidence_dir/logs-path.txt" agent-device logs path --platform "$platform"
+
+log_path="$(awk 'NF && $1 ~ /^\// { print $1; exit }' "$evidence_dir/logs-path.txt" 2>/dev/null || true)"
+if [ -n "$log_path" ] && [ -f "$log_path" ]; then
+  cp "$log_path" "$evidence_dir/device.log" || true
+  printf '{"name":"copy-device-log","exitCode":0,"durationMs":0,"artifact":"%s","artifactBytes":%s}\n' \
+    "$evidence_dir/device.log" "$(wc -c < "$evidence_dir/device.log" | tr -d ' ')" >> "$commands_file"
+else
+  printf '{"name":"copy-device-log","exitCode":1,"durationMs":0,"artifact":"%s","artifactBytes":null}\n' \
+    "$evidence_dir/device.log" >> "$commands_file"
+fi
+
+run_cmd close agent-device close --platform "$platform"

--- a/.github/scripts/judge-repro.py
+++ b/.github/scripts/judge-repro.py
@@ -136,7 +136,10 @@ def main() -> int:
             "platform": plat,
             "build_status": status,
             "repro_status": read_tail(f"evidence/{plat}/status.txt", limit=512),
-            "build_log_tail": read_tail(f"evidence/{plat}/xcodebuild.log", limit=12000),
+            "build_log_tail": (
+                read_tail(f"evidence/{plat}/xcodebuild.log", limit=12000)
+                or read_tail(f"evidence/{plat}/gradle.log", limit=12000)
+            ),
             "snapshot": read_tail(f"evidence/{plat}/snapshot.txt"),
             "snapshot_interactive": read_tail(f"evidence/{plat}/snapshot-interactive.txt"),
             "logs": read_head_and_tail(f"evidence/{plat}/device.log"),
@@ -145,6 +148,8 @@ def main() -> int:
             # native crash). Strongest signal for launch-time crashes.
             "app_console_tail": read_tail(f"evidence/{plat}/app.console.log", limit=12000),
             "agent_device_errors": read_tail(f"evidence/{plat}/agent-device.log", limit=4000),
+            "agent_device_version": read_tail(f"evidence/{plat}/agent-device-version.txt", limit=200),
+            "agent_device_commands": read_tail(f"evidence/{plat}/commands.jsonl", limit=4000),
         }
         packet["evidence_summary"] = summarize_evidence(packet)
         platforms.append(packet)

--- a/.github/scripts/repro-common.sh
+++ b/.github/scripts/repro-common.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+scaffold_repro() {
+  local channel="latest"
+  local flags=(--nativewind)
+
+  case "${SCAFFOLD_FLAVOR:-latest-plain}" in
+    next-expo-router)
+      channel="next"
+      flags=(--nativewind --expo-router)
+      ;;
+    next-react-navigation)
+      channel="next"
+      flags=(--nativewind --reactNavigation)
+      ;;
+    next-plain)
+      channel="next"
+      ;;
+    latest-expo-router)
+      flags=(--nativewind --expo-router)
+      ;;
+    latest-react-navigation)
+      flags=(--nativewind --reactNavigation)
+      ;;
+  esac
+
+  echo "Scaffolding rn-new@$channel repro ${flags[*]} --default --noInstall --noGit"
+  npx --yes "rn-new@$channel" repro "${flags[@]}" --default --noInstall --noGit
+  test -d repro && test -f repro/package.json
+}
+
+install_repro_dependencies() {
+  local repro_dir="${1:-repro}"
+
+  cd "$repro_dir"
+  if [ -f yarn.lock ]; then
+    corepack enable
+    yarn install --frozen-lockfile || yarn install
+  elif [ -f pnpm-lock.yaml ]; then
+    corepack enable
+    pnpm install --frozen-lockfile || pnpm install
+  elif [ -f package-lock.json ]; then
+    npm ci || npm install
+  elif [ -f bun.lockb ]; then
+    npm i -g bun
+    bun install
+  else
+    npm install
+  fi
+}
+
+case "${1:-}" in
+  scaffold)
+    scaffold_repro
+    ;;
+  install-deps)
+    install_repro_dependencies "${2:-repro}"
+    ;;
+  *)
+    echo "Usage: $0 {scaffold|install-deps [repro-dir]}" >&2
+    exit 2
+    ;;
+esac

--- a/.github/workflows/issue-repro.yml
+++ b/.github/workflows/issue-repro.yml
@@ -320,6 +320,14 @@ jobs:
         with:
           node-version: "22"
 
+      - name: Check out workflow scripts
+        uses: actions/checkout@v4
+        with:
+          path: nativewind-workflow
+          sparse-checkout: |
+            .github/scripts
+          sparse-checkout-cone-mode: false
+
       - name: Checkout reproduction repository
         if: env.HAS_REPRO == 'true'
         uses: actions/checkout@v4
@@ -330,30 +338,10 @@ jobs:
 
       - name: Scaffold rn-new starter (no repro link in issue)
         if: env.HAS_REPRO != 'true'
-        run: |
-          set -euo pipefail
-          case "$SCAFFOLD_FLAVOR" in
-            next-expo-router)        FLAGS="--nativewind --expo-router";       CHANNEL=next ;;
-            next-react-navigation)   FLAGS="--nativewind --reactNavigation";   CHANNEL=next ;;
-            next-plain)              FLAGS="--nativewind";                     CHANNEL=next ;;
-            latest-expo-router)      FLAGS="--nativewind --expo-router";       CHANNEL=latest ;;
-            latest-react-navigation) FLAGS="--nativewind --reactNavigation";   CHANNEL=latest ;;
-            *)                       FLAGS="--nativewind";                     CHANNEL=latest ;;
-          esac
-          echo "Scaffolding rn-new@$CHANNEL repro $FLAGS --default --noInstall --noGit"
-          npx --yes "rn-new@$CHANNEL" repro $FLAGS --default --noInstall --noGit
-          test -d repro && test -f repro/package.json
+        run: bash nativewind-workflow/.github/scripts/repro-common.sh scaffold
 
       - name: Install reproduction dependencies
-        working-directory: repro
-        run: |
-          set -euo pipefail
-          if   [ -f yarn.lock ];         then corepack enable && yarn install --frozen-lockfile || yarn install
-          elif [ -f pnpm-lock.yaml ];    then corepack enable && pnpm install --frozen-lockfile || pnpm install
-          elif [ -f package-lock.json ]; then npm ci || npm install
-          elif [ -f bun.lockb ];         then npm i -g bun && bun install
-          else                                npm install
-          fi
+        run: bash nativewind-workflow/.github/scripts/repro-common.sh install-deps repro
 
       - name: Prebuild iOS
         working-directory: repro
@@ -400,7 +388,8 @@ jobs:
           BUNDLE_CONFIG_PLATFORM: ios
         run: |
           set -euo pipefail
-          WORKSPACE=$(ls -1d *.xcworkspace | head -n 1)
+          WORKSPACE=$(find . -maxdepth 1 -name "*.xcworkspace" -type d -print -quit)
+          WORKSPACE=${WORKSPACE#./}
           SCHEME=$(basename "$WORKSPACE" .xcworkspace)
           echo "Building workspace=$WORKSPACE scheme=$SCHEME"
           # ONLY_ACTIVE_ARCH=YES keeps us from also building the dead
@@ -434,12 +423,44 @@ jobs:
           cp /tmp/xcodebuild.log ../../evidence/ios/xcodebuild.log || true
           if [ "$BUILD_STATUS" -ne 0 ]; then
             echo "::warning::xcodebuild failed with status $BUILD_STATUS (continuing so the judge sees the log)"
-            echo "built=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "built=false"
+              echo "build_outcome=xcodebuild-failed"
+            } >> "$GITHUB_OUTPUT"
             tail -200 /tmp/xcodebuild.log
             exit 0
           fi
           APP_PATH=$(find build/DerivedData/Build/Products/Debug-iphonesimulator -maxdepth 2 -name "*.app" -type d | head -n 1)
+          if [ -z "$APP_PATH" ] || [ ! -d "$APP_PATH" ]; then
+            echo "::warning::xcodebuild completed but no simulator .app was found"
+            {
+              echo "status=app-missing"
+              echo "note=xcodebuild completed, but no simulator .app was found."
+              echo "see=xcodebuild.log"
+            } > ../../evidence/ios/status.txt
+            {
+              echo "built=false"
+              echo "build_outcome=app-missing"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          set +e
           BUNDLE_ID=$(plutil -extract CFBundleIdentifier raw "$APP_PATH/Info.plist")
+          BUNDLE_ID_STATUS=$?
+          set -e
+          if [ "$BUNDLE_ID_STATUS" -ne 0 ] || [ -z "$BUNDLE_ID" ]; then
+            echo "::warning::Could not determine iOS bundle identifier"
+            {
+              echo "status=bundle-id-missing"
+              echo "note=The app was built, but CFBundleIdentifier could not be read."
+              echo "see=xcodebuild.log"
+            } > ../../evidence/ios/status.txt
+            {
+              echo "built=false"
+              echo "build_outcome=bundle-id-missing"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
           # Belt-and-suspenders: if the Xcode bundle phase still no-op'd
           # (e.g. with-environment.sh clobbered our FORCE_BUNDLING), run
@@ -464,71 +485,44 @@ jobs:
             fi
             popd > /dev/null
           fi
-          echo "built=true"                 >> "$GITHUB_OUTPUT"
-          echo "app_path=$(pwd)/$APP_PATH" >> "$GITHUB_OUTPUT"
-          echo "bundle_id=$BUNDLE_ID"      >> "$GITHUB_OUTPUT"
+          if [ ! -s "$APP_PATH/main.jsbundle" ]; then
+            echo "::warning::main.jsbundle is still missing after fallback bundling"
+            {
+              echo "status=bundle-missing"
+              echo "note=The app built, but no main.jsbundle was embedded, so user JS would not run."
+              echo "see=xcodebuild.log"
+            } > ../../evidence/ios/status.txt
+            {
+              echo "built=false"
+              echo "build_outcome=bundle-missing"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          {
+            echo "built=true"
+            echo "build_outcome=built"
+            echo "app_path=$(pwd)/$APP_PATH"
+            echo "bundle_id=$BUNDLE_ID"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Install agent-device
         if: steps.build.outputs.built == 'true'
-        run: npm install -g agent-device@0.15.2
+        run: npm install -g agent-device@0.18.0
 
       - name: Boot iOS simulator
         if: steps.build.outputs.built == 'true'
         run: agent-device boot --platform ios 2>> evidence/ios/agent-device.log
 
-      - name: Install app on simulator
-        if: steps.build.outputs.built == 'true'
-        env:
-          APP_PATH: ${{ steps.build.outputs.app_path }}
-          BUNDLE_ID: ${{ steps.build.outputs.bundle_id }}
-        run: agent-device install "$BUNDLE_ID" "$APP_PATH" --platform ios 2>> evidence/ios/agent-device.log
-
-      - name: Launch app and start scoped logs
-        id: console
-        if: steps.build.outputs.built == 'true'
-        continue-on-error: true
-        env:
-          BUNDLE_ID: ${{ steps.build.outputs.bundle_id }}
-        run: |
-          set +e
-          exec 2>> evidence/ios/agent-device.log
-          agent-device --debug \
-            open "$BUNDLE_ID" --platform ios \
-            --save-script evidence/ios/launch.ad
-          agent-device logs clear --restart
-          agent-device \
-            open "$BUNDLE_ID" --platform ios --relaunch \
-            --launch-console evidence/ios/app.console.log
-          agent-device wait 25000
-          exit 0
-
-      - name: Capture UI evidence via agent-device
+      - name: Install app and capture iOS evidence via agent-device
         id: capture
         if: steps.build.outputs.built == 'true'
         continue-on-error: true
+        env:
+          APP_PATH: ${{ steps.build.outputs.app_path }}
+          BUNDLE_ID: ${{ steps.build.outputs.bundle_id }}
         run: |
-          # Cheap signals first. Snapshot can be slower or time out when the
-          # app has crashed, so keep screenshot, perf, console, and logs as
-          # robust evidence even when accessibility capture fails.
-          set +e
-          exec 2>> evidence/ios/agent-device.log
-          agent-device \
-            screenshot evidence/ios/screen.png
-          agent-device perf --json \
-            > evidence/ios/perf.json
-          # Snapshots last — these are the ones that historically time out.
-          agent-device snapshot \
-            > evidence/ios/snapshot.txt
-          agent-device snapshot -i \
-            > evidence/ios/snapshot-interactive.txt
-          agent-device logs path \
-            > evidence/ios/logs-path.txt
-          LOG_PATH="$(head -n 1 evidence/ios/logs-path.txt || true)"
-          if [ -n "$LOG_PATH" ] && [ -f "$LOG_PATH" ]; then
-            cp "$LOG_PATH" evidence/ios/device.log
-          fi
-          agent-device close
-          exit 0
+          bash nativewind-workflow/.github/scripts/capture-agent-device.sh \
+            ios "$BUNDLE_ID" "$APP_PATH" evidence/ios
 
       - name: Export agent-device diagnostics
         if: always()
@@ -544,6 +538,9 @@ jobs:
       - name: Record build-only outcome
         if: steps.build.outputs.built != 'true'
         run: |
+          if [ -f evidence/ios/status.txt ]; then
+            exit 0
+          fi
           {
             echo "status=build-failed"
             echo "note=xcodebuild failed before the app could be launched on a simulator."
@@ -593,6 +590,14 @@ jobs:
           java-version: "17"
           distribution: temurin
 
+      - name: Check out workflow scripts
+        uses: actions/checkout@v4
+        with:
+          path: nativewind-workflow
+          sparse-checkout: |
+            .github/scripts
+          sparse-checkout-cone-mode: false
+
       - name: Checkout reproduction repository
         if: env.HAS_REPRO == 'true'
         uses: actions/checkout@v4
@@ -603,30 +608,10 @@ jobs:
 
       - name: Scaffold rn-new starter (no repro link in issue)
         if: env.HAS_REPRO != 'true'
-        run: |
-          set -euo pipefail
-          case "$SCAFFOLD_FLAVOR" in
-            next-expo-router)        FLAGS="--nativewind --expo-router";       CHANNEL=next ;;
-            next-react-navigation)   FLAGS="--nativewind --reactNavigation";   CHANNEL=next ;;
-            next-plain)              FLAGS="--nativewind";                     CHANNEL=next ;;
-            latest-expo-router)      FLAGS="--nativewind --expo-router";       CHANNEL=latest ;;
-            latest-react-navigation) FLAGS="--nativewind --reactNavigation";   CHANNEL=latest ;;
-            *)                       FLAGS="--nativewind";                     CHANNEL=latest ;;
-          esac
-          echo "Scaffolding rn-new@$CHANNEL repro $FLAGS --default --noInstall --noGit"
-          npx --yes "rn-new@$CHANNEL" repro $FLAGS --default --noInstall --noGit
-          test -d repro && test -f repro/package.json
+        run: bash nativewind-workflow/.github/scripts/repro-common.sh scaffold
 
       - name: Install reproduction dependencies
-        working-directory: repro
-        run: |
-          set -euo pipefail
-          if   [ -f yarn.lock ];         then corepack enable && yarn install --frozen-lockfile || yarn install
-          elif [ -f pnpm-lock.yaml ];    then corepack enable && pnpm install --frozen-lockfile || pnpm install
-          elif [ -f package-lock.json ]; then npm ci || npm install
-          elif [ -f bun.lockb ];         then npm i -g bun && bun install
-          else                                npm install
-          fi
+        run: bash nativewind-workflow/.github/scripts/repro-common.sh install-deps repro
 
       - name: Prebuild Android
         working-directory: repro
@@ -636,25 +621,78 @@ jobs:
             npx --yes expo prebuild --platform android --no-install
           fi
 
+      - name: Prepare evidence directory
+        run: mkdir -p evidence/android
+
       - name: Build Android APK (debug)
         id: build
+        continue-on-error: true
         working-directory: repro/android
         run: |
           set -euo pipefail
           chmod +x ./gradlew
-          ./gradlew :app:assembleDebug --no-daemon
+          set +e
+          ./gradlew :app:assembleDebug --no-daemon 2>&1 | tee ../../evidence/android/gradle.log
+          BUILD_STATUS=${PIPESTATUS[0]}
+          set -e
+          if [ "$BUILD_STATUS" -ne 0 ]; then
+            echo "::warning::Gradle failed with status $BUILD_STATUS (continuing so the judge sees the log)"
+            {
+              echo "status=build-failed"
+              echo "note=Gradle failed before the app could be launched on an emulator."
+              echo "see=gradle.log"
+            } > ../../evidence/android/status.txt
+            {
+              echo "built=false"
+              echo "build_outcome=gradle-failed"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           APK=$(find app/build/outputs/apk/debug -name "*.apk" | head -n 1)
-          PKG=$(${ANDROID_HOME}/build-tools/$(ls ${ANDROID_HOME}/build-tools | tail -n 1)/aapt dump badging "$APK" | awk -F"'" '/package: name=/{print $2}')
-          echo "apk=$(pwd)/$APK" >> "$GITHUB_OUTPUT"
-          echo "package=$PKG"     >> "$GITHUB_OUTPUT"
+          if [ ! -s "$APK" ]; then
+            echo "::warning::Gradle completed but no debug APK was found"
+            {
+              echo "status=apk-missing"
+              echo "note=Gradle completed, but no debug APK was found."
+              echo "see=gradle.log"
+            } > ../../evidence/android/status.txt
+            {
+              echo "built=false"
+              echo "build_outcome=apk-missing"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          set +e
+          BUILD_TOOLS_DIR=$(find "$ANDROID_HOME/build-tools" -mindepth 1 -maxdepth 1 -type d | sort | tail -n 1)
+          PKG=$("$BUILD_TOOLS_DIR/aapt" dump badging "$APK" | awk -F"'" '/package: name=/{print $2}')
+          PKG_STATUS=$?
+          set -e
+          if [ "$PKG_STATUS" -ne 0 ] || [ -z "$PKG" ]; then
+            echo "::warning::Could not determine Android package name"
+            {
+              echo "status=package-missing"
+              echo "note=The APK was built, but the package name could not be determined."
+              echo "see=gradle.log"
+            } > ../../evidence/android/status.txt
+            {
+              echo "built=false"
+              echo "build_outcome=package-missing"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          {
+            echo "built=true"
+            echo "build_outcome=built"
+            echo "apk=$(pwd)/$APK"
+            echo "package=$PKG"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Install agent-device
-        run: npm install -g agent-device@0.15.2
-
-      - name: Prepare evidence directory
-        run: mkdir -p evidence/android
+        if: steps.build.outputs.built == 'true'
+        run: npm install -g agent-device@0.18.0
 
       - name: Run app on Android emulator + capture evidence
+        if: steps.build.outputs.built == 'true'
         uses: reactivecircus/android-emulator-runner@v2
         continue-on-error: true
         env:
@@ -669,47 +707,9 @@ jobs:
           disable-animations: true
           script: |
             # NB: android-emulator-runner runs this under /bin/sh (dash),
-            # which doesn't support `pipefail`. Keep collecting evidence
-            # even when one capture channel fails.
-            set +e
-            agent-device \
-              install "$APP_PACKAGE" "$APK_PATH" --platform android \
-              2>> evidence/android/agent-device.log
-
-            agent-device \
-              open "$APP_PACKAGE" --platform android \
-              --save-script evidence/android/launch.ad \
-              2>> evidence/android/agent-device.log
-            agent-device logs clear --restart \
-              2>> evidence/android/agent-device.log
-            agent-device \
-              open "$APP_PACKAGE" --platform android --relaunch \
-              2>> evidence/android/agent-device.log
-
-            agent-device wait 25000 \
-              2>> evidence/android/agent-device.log
-
-            agent-device \
-              screenshot evidence/android/screen.png \
-              2>> evidence/android/agent-device.log
-            agent-device perf --json \
-              > evidence/android/perf.json \
-              2>> evidence/android/agent-device.log
-            agent-device snapshot \
-              > evidence/android/snapshot.txt \
-              2>> evidence/android/agent-device.log
-            agent-device snapshot -i \
-              > evidence/android/snapshot-interactive.txt \
-              2>> evidence/android/agent-device.log
-            agent-device logs path \
-              > evidence/android/logs-path.txt \
-              2>> evidence/android/agent-device.log
-            LOG_PATH="$(head -n 1 evidence/android/logs-path.txt || true)"
-            if [ -n "$LOG_PATH" ] && [ -f "$LOG_PATH" ]; then
-              cp "$LOG_PATH" evidence/android/device.log
-            fi
-            agent-device close \
-              2>> evidence/android/agent-device.log
+            # so the shared capture helper owns command status handling.
+            bash nativewind-workflow/.github/scripts/capture-agent-device.sh \
+              android "$APP_PACKAGE" "$APK_PATH" evidence/android
 
       - name: Export Android agent-device diagnostics
         if: always()


### PR DESCRIPTION
## Summary

Upgrade the issue reproduction workflow to agent-device 0.18.0 and share scaffold/dependency setup across iOS and Android.

Capture agent-device command status/version evidence, prepare the iOS runner before capture, and record explicit build/bundle failure statuses instead of launching apps when runtime evidence would be misleading.

## Validation

- bash -n .github/scripts/repro-common.sh
- bash -n .github/scripts/capture-agent-device.sh
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/issue-repro.yml"); puts "ok"'
- python3 -c 'import ast, pathlib; ast.parse(pathlib.Path(".github/scripts/judge-repro.py").read_text()); print("ok")'
- actionlint .github/workflows/issue-repro.yml
- smoke-tested capture-agent-device.sh with a fake agent-device binary