### PR TITLE
fix: upgrade warning crashes (throwing getters) or hangs (exponential re-walk) the app

### DIFF
--- a/.changeset/upgrade-warning-stringify.md
+++ b/.changeset/upgrade-warning-stringify.md
@@ -1,0 +1,9 @@
+---
+"react-native-css-interop": patch
+---
+
+Fix the dev-only upgrade warning crashing or hanging apps: `printUpgradeWarning`'s
+props serializer invoked throwing property getters (e.g. React Navigation's default
+context value, surfacing as "Couldn't find a navigation context" render errors) and
+re-walked shared subtrees exponentially. The walk is now bounded, exception-safe, and
+skips repeat visits, so the warning always prints instead of crashing the render.

--- a/packages/react-native-css-interop/src/runtime/native/render-component.tsx
+++ b/packages/react-native-css-interop/src/runtime/native/render-component.tsx
@@ -234,32 +234,61 @@ function printUpgradeWarning(
 }
 
 function stringify(object: any) {
+  // The props graph can contain objects with throwing getters (e.g. React Navigation's
+  // default context value throws "Couldn't find a navigation context" on access) and
+  // heavily shared subtrees (React elements). The previous implementation invoked every
+  // getter via Object.entries — turning this dev-only warning into a render crash — and
+  // deleted nodes from `seen` after visiting, so shared (non-circular) subtrees were
+  // re-walked exponentially, hanging the JS thread. Bounded and exception-safe instead.
   const seen = new WeakSet();
-  return JSON.stringify(
-    object,
-    function replace(_, value) {
-      if (!(value !== null && typeof value === "object")) {
-        return value;
+  const MAX_DEPTH = 3;
+  const MAX_ENTRIES = 20;
+
+  const walk = (value: any, depth: number): any => {
+    if (value === null || typeof value !== "object") {
+      return typeof value === "function" ? "[Function]" : value;
+    }
+
+    if (seen.has(value)) {
+      return "[Circular]";
+    }
+
+    if (depth >= MAX_DEPTH) {
+      return Array.isArray(value) ? "[Array]" : "[Object]";
+    }
+
+    seen.add(value);
+
+    const newValue: any = Array.isArray(value) ? [] : {};
+
+    let entries: [string, any][];
+    try {
+      entries = Object.entries(value);
+    } catch {
+      return "[Unserializable]";
+    }
+
+    let count = 0;
+    for (const entry of entries) {
+      if (++count > MAX_ENTRIES) {
+        newValue["…"] = "[Truncated]";
+        break;
       }
-
-      if (seen.has(value)) {
-        return "[Circular]";
+      try {
+        newValue[entry[0]] = walk(entry[1], depth + 1);
+      } catch {
+        newValue[entry[0]] = "[Unserializable]";
       }
+    }
 
-      seen.add(value);
+    return newValue;
+  };
 
-      const newValue: any = Array.isArray(value) ? [] : {};
-
-      for (const entry of Object.entries(value)) {
-        newValue[entry[0]] = replace(entry[0], entry[1]);
-      }
-
-      seen.delete(value);
-
-      return newValue;
-    },
-    2,
-  );
+  try {
+    return JSON.stringify(walk(object, 0), null, 2);
+  } catch {
+    return "[Unserializable props]";
+  }
 }
 
 // const ForwardRefSymbol = Symbol.for("react.forward_ref");


### PR DESCRIPTION
Fixes #1812; also the root cause behind the crash symptom in #1711 (and likely #1472 / #1712).

## The bug

`printUpgradeWarning` serializes the offending component's props with a naive deep walk. Two independent failure modes turn this **dev-only diagnostic** into an app killer:

1. **Crash:** `Object.entries` invokes property getters. Libraries ship defensive getters that throw — React Navigation's default context value throws `Couldn't find a navigation context` on access. The throw happens inside the template literal, **before `console.log` runs**, so the warning never prints and the redbox blames whatever innocent component was rendering (in our app: a plain `View` inside a card). This is why these reports are so hard to reproduce/diagnose — the diagnostic destroys its own evidence.

2. **Hang:** the walker deletes nodes from `seen` after visiting, so *shared but non-circular* subtrees — ubiquitous in React element graphs (`children` arrays, `_owner`, context objects) — are re-walked exponentially. If nothing throws early, the JS thread locks up instead. (We hit this exact sequence: patching away the throw un-crashed the walk straight into a multi-second-to-forever hang.)

## Repro that hits both

A css-interop `View` inside a React Navigation screen whose `className` conditionally **gains** `shadow-md` after first render — Tailwind shadows set `--tw-shadow` variables, so the element crosses the *variables upgrade* boundary mid-lifecycle and the warning fires:

```tsx
const [star, setStar] = useState(false);
// mounts without a shadow → later gains one → variables upgrade → warning → crash
<View className={star ? 'rounded-md border shadow-md' : 'rounded-md border'} />
```

## The fix

Transform-then-stringify with a bounded, exception-safe walk:
- per-property `try/catch` (throwing getters render as `[Unserializable]`),
- depth cap (3) + entries cap (20) — the warning's purpose is showing `className`/`testID`, not the whole element graph,
- no `seen`-delete: repeat visits short-circuit as `[Circular]`, killing the exponential re-walk.

Verified on a real app (Expo SDK 57, RN new-arch, React Navigation v7): the previously-crashing interaction now prints the warning cleanly, naming the upgrade type and the exact `className` — which is precisely what made the underlying app-level bug a one-line fix (`shadow-none` on the non-elevated variants).

Includes a changeset (patch bump for `react-native-css-interop`).