### PR TITLE
fix(metro): reject getCSSForPlatform when the Tailwind child dies before producing CSS

### DIFF
--- a/packages/nativewind/src/metro/tailwind/v3/index.ts
+++ b/packages/nativewind/src/metro/tailwind/v3/index.ts
@@ -20,6 +20,8 @@ import { TailwindCliOptions } from "../types";
 
 const child_file = __dirname + "/child.js";
 
+const INITIAL_BUILD_TIMEOUT_MS = 60_000;
+
 const getEnv = (options: TailwindCliOptions) => {
   return {
     ...process.env,
@@ -45,8 +47,37 @@ export const tailwindCliV3 = function (debug: Debugger) {
           let initialMessage = true;
           let initialDoneIn = true;
 
+          /*
+           * The promise must settle even when the Tailwind build crashes
+           * before its first IPC message, otherwise Metro waits on the
+           * virtual CSS module forever with no error shown anywhere:
+           * - non-watch mode: the child exits without sending -> reject on
+           *   "exit"/"error"
+           * - watch mode: tailwind --watch logs the error and keeps running,
+           *   leaving the child alive but forever silent -> reject after a
+           *   timeout
+           * Keep the stderr tail so the rejection carries the real error.
+           */
+          let stderrTail = "";
+          const initialFailure = (why: string) =>
+            new Error(
+              `NativeWind: Tailwind child ${why} before producing CSS - the bundle would hang silently. Tailwind output below.\n--- tailwind stderr ---\n${
+                stderrTail.trim() || "(empty)"
+              }`,
+            );
+          const initialTimer = setTimeout(() => {
+            if (initialMessage) {
+              reject(
+                initialFailure(
+                  `produced nothing within ${INITIAL_BUILD_TIMEOUT_MS / 1000}s`,
+                ),
+              );
+            }
+          }, INITIAL_BUILD_TIMEOUT_MS);
+
           child.stderr?.on("data", (data) => {
             data = data.toString();
+            stderrTail = (stderrTail + data).slice(-4000);
             if (data.includes("Done in")) {
               if (initialDoneIn) {
                 initialDoneIn = false;
@@ -60,8 +91,23 @@ export const tailwindCliV3 = function (debug: Debugger) {
             data = data.toString();
           });
 
+          child.on("error", (error) => {
+            if (initialMessage) {
+              clearTimeout(initialTimer);
+              reject(error);
+            }
+          });
+
+          child.on("exit", (code, signal) => {
+            if (initialMessage) {
+              clearTimeout(initialTimer);
+              reject(initialFailure(`exited (code=${code}, signal=${signal})`));
+            }
+          });
+
           child.on("message", (message) => {
             if (initialMessage) {
+              clearTimeout(initialTimer);
               resolve(message.toString());
               initialMessage = false;
               debug("Finished initial development Tailwind CLI");


### PR DESCRIPTION
## The bug

`tailwindCliV3.getCSSForPlatform` resolves its promise from the forked Tailwind child's **first IPC message**, but has no rejection path besides a synchronous `fork()` throw. If the Tailwind build fails before sending that message, the promise stays pending forever, and because the child's stderr is discarded (only `Done in` / `warn -` are inspected), the real error is never shown anywhere:

- **Dev server / watch mode:** `tailwind --watch` logs the compile error to (captured, discarded) stderr and keeps running — the child stays alive but forever silent. Metro hangs at the final module (`5125/5126`-style) with every process idle. Nothing in any terminal explains why.
- **`expo export` / non-watch:** the child exits 1 without sending. Worse than a hang: once the event loop drains with the promise still pending, **the export process can exit 0 mid-bundle** (we observed `0.0% (0/1)` bundled with a green exit code in CI), so even CI vouches for a broken bundle.

Any error thrown during the Tailwind build triggers this — we hit it in production via a tailwindcss 3.4.19 crash (`TypeError: Cannot read properties of undefined (reading 'raws')` in `generateRules`) caused by a stray content-scanner candidate `!-outline` extracted from a regex lookahead literal `(?!-outline)` in a scanned file. An OOM-kill or signal on the child produces the same silent hang. In our case this cost several days of debugging because the failure was invisible and reproduced identically across machines — it was mistaken for a local-environment issue.

### Minimal repro

In any NativeWind v4 + tailwindcss 3.x app, put this literal in any file matched by your `tailwind.config.js` `content` globs:

```ts
const re = /x(?!-outline)y/;
```

`npx expo start` then hangs forever at the last module; `npx expo export` hangs or exits 0 with an incomplete bundle. Running `npx tailwindcss -i ./global.css -o /tmp/out.css` by hand is the only way to see the real error.

## The fix

Three guards on the initial build, all no-ops once the first message has resolved the promise (watch-mode `onChange` behaviour is unchanged):

1. **Keep a tail of the child's stderr** (last 4000 chars) so the rejection can carry the real Tailwind error instead of discarding it.
2. **Reject on child `exit`/`error` before the first message** — covers the non-watch/export path and any crash/OOM/signal class, embedding the captured stderr.
3. **Reject after 60s of initial-build silence** — covers watch mode, where a failed initial build leaves the child alive but permanently quiet.

With this change the same repro fails in ~1s with:

```
Error: NativeWind: Tailwind child exited (code=1, signal=null) before producing CSS - the bundle would hang silently. Tailwind output below.
--- tailwind stderr ---
TypeError: Cannot read properties of undefined (reading 'raws')
    at resolveMatches (.../tailwindcss/lib/lib/generateRules.js:759:22)
    ...
```

which Metro/`react-native-css-interop` surfaces as a normal bundling error in both the dev server and `expo export` (verified: export exits 1 with the error printed; dev server shows a red-box/terminal error instead of hanging).

## Verification

Tested as a patch against the compiled `nativewind@4.2.6` output in a real Expo SDK 54 / RN-web app:

- **Crash path, export mode:** killer token present → rejects in ~1s, `expo export` exits 1 printing the real `generateRules` TypeError (previously: hang, or exit 0 mid-bundle).
- **Crash path, watch mode:** rejects at 60s with the captured stderr (previously: infinite silent hang).
- **Happy path:** resolves in ~1.1s with byte-identical CSS; watch-mode `onChange` unaffected.
- **Settle-safety:** message/exit/error/timeout all clear the timer or are no-ops after settlement; double-settle is impossible (single-threaded handlers flip `initialMessage` synchronously with `resolve`).

The 60s constant is generous (our initial build is ~1.1s) but exists only to convert an *infinite silent* hang into a *bounded loud* failure; happy to tune or make it configurable if you'd prefer.