### PR TITLE
fix: map tint utilities to native props

### DIFF
--- a/src/__tests__/custom.tsx
+++ b/src/__tests__/custom.tsx
@@ -1,5 +1,13 @@
 import { renderCurrentTest } from "../test-utils";
 
+describe("Custom - Tint Color", () => {
+  test("tint-black", async () => {
+    expect(await renderCurrentTest()).toStrictEqual({
+      props: { tint: "#000", style: {} },
+    });
+  });
+});
+
 describe("Custom - Ripple Color", () => {
   test("ripple-black", async () => {
     expect(await renderCurrentTest()).toStrictEqual({

--- a/theme.css
+++ b/theme.css
@@ -39,7 +39,9 @@
 
 @utility tint-* {
   -rn-tint: --value(--color-*);
-  @prop -rn-tint tint;
+  @nativeMapping {
+    -rn-tint: tint;
+  }
 }
 
 @utility ripple-* {


### PR DESCRIPTION
## Summary

- Replace the removed `@prop` directive in `tint-*` with `@nativeMapping`.
- Use block syntax so Tailwind preserves the mapping while expanding the custom utility.
- Add a regression test confirming `tint-black` reaches the top-level `tint` prop and leaves `style` empty.

Fixes #1837

## Why

`react-native-css` 3 recognizes `@nativeMapping`, not the old `@prop` directive. Without the mapping, `tint-black` compiles to `style.tint`, which React Native ignores for the intended component prop. A statement-form unknown at-rule is also dropped during Tailwind utility expansion; the block form survives and compiles the color to the native `tint` path.

## Test plan

- Confirmed the new regression test fails before the fix with `{ style: { tint: "#000" } }`.
- `yarn install --immutable`
- `yarn lint`
- `yarn typecheck`
- `yarn build`
- `yarn test --maxWorkers=2 --coverage` (7 suites, 36 tests)
- `yarn example expo export --platform web`
- `yarn pack --dry-run`