### PR TITLE
fix(v4): border-s-* and border-e-* colors defined with CSS variables

### DIFF
--- a/.changeset/logical-border-var-colors.md
+++ b/.changeset/logical-border-var-colors.md
@@ -1,0 +1,7 @@
+---
+"react-native-css-interop": patch
+---
+
+Fix `border-s-*` and `border-e-*` colors defined with CSS variables
+
+Colors containing `var()` (e.g. shadcn-style `hsl(var(--primary))` theme colors) take the unparsed declaration path, whose property mapping was missing the `border-inline-*` entries the parsed path already had. The property leaked through as `borderInlineStartColor`/`borderInlineEndColor`, which React Native silently drops. These now map to `border-left/right-color` and `border-left/right-width`, matching the behavior of literal colors.

--- a/packages/nativewind/src/__tests__/borders.tsx
+++ b/packages/nativewind/src/__tests__/borders.tsx
@@ -274,6 +274,58 @@ describe("Border - Border Color", () => {
   });
 });
 
+describe("Border - Logical Border Color", () => {
+  test("border-s-white", async () => {
+    expect(await renderCurrentTest()).toStrictEqual({
+      props: { style: { borderLeftColor: "#ffffff" } },
+    });
+  });
+
+  test("border-e-white", async () => {
+    expect(await renderCurrentTest()).toStrictEqual({
+      props: { style: { borderRightColor: "#ffffff" } },
+    });
+  });
+
+  // https://github.com/nativewind/nativewind/issues/1737
+  // Colors defined with var() take the unparsed path, which previously
+  // missed the border-inline-* to border-left/right-* mappings
+  const variableColorOptions = {
+    css: `
+      @tailwind base;
+      @tailwind components;
+      @tailwind utilities;
+
+      @layer base {
+        :root {
+          --color-primary: 255 115 179;
+        }
+      }
+    `,
+    config: {
+      theme: {
+        extend: {
+          colors: {
+            primary: "rgb(var(--color-primary) / <alpha-value>)",
+          },
+        },
+      },
+    },
+  };
+
+  test("border-s-primary", async () => {
+    expect(await renderCurrentTest(variableColorOptions)).toStrictEqual({
+      props: { style: { borderLeftColor: "rgba(255, 115, 179, 1)" } },
+    });
+  });
+
+  test("border-e-primary", async () => {
+    expect(await renderCurrentTest(variableColorOptions)).toStrictEqual({
+      props: { style: { borderRightColor: "rgba(255, 115, 179, 1)" } },
+    });
+  });
+});
+
 describe("Borders - Border Style", () => {
   test("border-solid", async () => {
     expect(await renderCurrentTest()).toStrictEqual({

--- a/packages/react-native-css-interop/src/css-to-rn/parseDeclaration.ts
+++ b/packages/react-native-css-interop/src/css-to-rn/parseDeclaration.ts
@@ -55,6 +55,12 @@ import { FeatureFlagStatus } from "./feature-flags";
 import { toRNProperty } from "./normalize-selectors";
 
 const unparsedPropertyMapping: Record<string, string> = {
+  // Matches the physical-side mapping the parsed path uses for these
+  // properties, so literal and var() based values stay consistent
+  "border-inline-end-color": "border-right-color",
+  "border-inline-end-width": "border-right-width",
+  "border-inline-start-color": "border-left-color",
+  "border-inline-start-width": "border-left-width",
   "margin-inline-start": "margin-start",
   "margin-inline-end": "margin-end",
   "padding-inline-start": "padding-start",


### PR DESCRIPTION
Fixes #1737 for v4. The v5 equivalent landed as nativewind/react-native-css#379.

## What

border-s-* and border-e-* worked with literal theme colors but not with colors defined via CSS variables (e.g. shadcn-style hsl(var(--primary))). Literal values take the parsed path, which remaps border-inline-start-color to border-left-color. Values containing var() take the unparsed path, which relies on unparsedPropertyMapping, and that map only had margin and padding entries. The property leaked through as borderInlineStartColor, which React Native silently drops.

## How

Adds the border-inline color and width entries to unparsedPropertyMapping, mapping to the same physical border-left/right-* props the parsed path uses. Kept physical sides rather than RN's borderStartColor so literal and var() based values stay consistent with existing v4 behavior.

## Tests

Added a Logical Border Color block to borders.tsx: literal border-s-white / border-e-white, plus border-s-primary / border-e-primary with a rgb(var(--color-primary)) theme color reproducing the issue. The variable tests fail without the fix and pass with it. Full suites pass: react-native-css-interop 160, nativewind 788. Typecheck failures on this branch (8 and 2 errors) are identical on clean v4 and unrelated.

Includes a changeset (react-native-css-interop patch).
