### PR TITLE
fix(react-native-css-interop): box-shadow falls through into aspect-ratio

### DIFF
--- a/packages/react-native-css-interop/src/__tests__/compiler.test.tsx
+++ b/packages/react-native-css-interop/src/__tests__/compiler.test.tsx
@@ -42,3 +42,30 @@ test("will merge static styles", () => {
     },
   });
 });
+
+test("box-shadow does not fall through into aspect-ratio", () => {
+  const compiled = cssToReactNativeRuntime(`
+    .test {
+      box-shadow: 0 0 4px red;
+      aspect-ratio: 16 / 9;
+    }
+  `);
+
+  const [[declarations]] = (compiled.rules.test as any).n[0].d;
+
+  expect(declarations).toStrictEqual({
+    shadowColor: "#ff0000",
+    shadowRadius: 0,
+    aspectRatio: "16 / 9",
+  });
+});
+
+test("box-shadow alone does not crash", () => {
+  expect(() =>
+    cssToReactNativeRuntime(`
+      .test {
+        box-shadow: 0 0 4px red;
+      }
+    `),
+  ).not.toThrow();
+});

--- a/packages/react-native-css-interop/src/css-to-rn/parseDeclaration.ts
+++ b/packages/react-native-css-interop/src/css-to-rn/parseDeclaration.ts
@@ -1555,7 +1555,7 @@ export function parseDeclaration(
         parseTextAlign(declaration.value, parseOptions),
       );
     case "box-shadow": {
-      parseBoxShadow(declaration.value, parseOptions);
+      return parseBoxShadow(declaration.value, parseOptions);
     }
     case "aspect-ratio": {
       return addStyleProp(


### PR DESCRIPTION
## Summary
`parseDeclaration`'s `case "box-shadow"` had no `return`, so execution
fell through into the adjacent `case "aspect-ratio"` and called
`parseAspectRatio` with the box-shadow value. `parseAspectRatio` accesses
`.ratio` on its argument, which throws when given a box-shadow value.

This only affects `box-shadow` declarations whose value is a static
literal (e.g. `box-shadow: 0 0 4px red`), which lightningcss parses into
a structured `BoxShadow[]` and routes through this switch as
`property === "box-shadow"`. Declarations built from CSS custom
properties (e.g. Tailwind's generated
`box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow)`,
used by all of Tailwind's preset `shadow-*` utilities) are classified as
`property === "unparsed"` and never reach this switch — so most
Tailwind users won't hit this. It reproduces whenever a rule sets
`box-shadow` via a literal value, e.g. a hand-written CSS class or a
Tailwind arbitrary value like `shadow-[0_0_4px_red]`.

## Fix
Added the missing `return` to stop the fall-through.

## Test plan
- Added a regression test asserting `box-shadow` (literal value) +
  `aspect-ratio` on the same rule both compile correctly.
- Added a regression test asserting `box-shadow` (literal value) alone
  does not throw.
- Verified both new tests fail on the pre-fix code (reproduced the
  `Cannot read properties of undefined (reading '0')` crash) and pass
  after the fix.
- Reproduced independently in a real app: a hand-written CSS class with
  a literal `box-shadow` (bypassing Tailwind's `--tw-shadow` variable
  system) triggered the exact same crash/stack trace at build time.