### PR TITLE
[v4] fix(react-native-css-interop): declaration guard retains previousState, leaking every past render

### DIFF
--- a/.changeset/declaration-guard-retains-previous-state.md
+++ b/.changeset/declaration-guard-retains-previous-state.md
@@ -1,0 +1,9 @@
+---
+"react-native-css-interop": patch
+---
+
+Fix the declaration guard retaining more state than it compares
+
+`getDeclarations` built its guard closure inline, so the closure captured that function's environment rather than the three values it actually compares. Under Hermes `-Og` (dev builds) that environment holds every local and parameter, `previousState` included, so each render linked its state to the previous one through `declarationTracking.guards` — a chain that grew by one link per render and kept every past render alive, along with the element tree held by each state's `props`. Resetting `guards: []` does not help: the array is new, but the closures already created still reference the environment. Under `-O` (release builds) the environment narrows to `config` and `state`, which removes the generational chain but still pins that render's state.
+
+The guard is now built by a factory that only receives `config`, `className` and `inline`, so nothing beyond those is captured.

--- a/packages/react-native-css-interop/src/runtime/native/native-interop.ts
+++ b/packages/react-native-css-interop/src/runtime/native/native-interop.ts
@@ -51,7 +51,13 @@ import {
   getStyle,
   VariableContext,
 } from "./styles";
-import { ReducerAction, ReducerState, Refs, SharedState } from "./types";
+import {
+  ReducerAction,
+  ReducerState,
+  Refs,
+  RenderingGuard,
+  SharedState,
+} from "./types";
 
 export function interop(
   component: ReactComponent<any>,
@@ -348,6 +354,30 @@ function initReducer({
   );
 }
 
+/**
+ * Creates the declaration guard outside of `getDeclarations`, so the closure only
+ * captures the three values it actually compares.
+ *
+ * Declared inline, the guard captures `getDeclarations`'s environment instead:
+ *
+ * - Hermes `-Og` (dev builds) keeps every local and parameter in that environment,
+ *   `previousState` included. Each render then links its state to the previous one
+ *   through `declarationTracking.guards`, so the whole render history — and the
+ *   element tree held by each state's `props` — stays reachable.
+ * - Hermes `-O` (release builds) narrows the environment to `config` and `state`.
+ *   The generational chain is gone, but the guard still pins that render's state
+ *   for as long as the tracking object lives.
+ */
+function makeDeclarationGuard(
+  config: ReducerState["config"],
+  className: ReducerState["className"],
+  inline: ReducerState["inline"],
+): RenderingGuard {
+  return (refs) =>
+    !Object.is(refs.props?.[config.source], className) ||
+    !Object.is(getTarget(refs.props, config), inline);
+}
+
 function getDeclarations(
   previousState: ReducerState,
   refs: Refs,
@@ -386,9 +416,7 @@ function getDeclarations(
   }
 
   state.declarationTracking.guards.push(
-    (refs) =>
-      !Object.is(refs.props?.[config.source], state.className) ||
-      !Object.is(getTarget(refs.props, config), state.inline),
+    makeDeclarationGuard(config, state.className, state.inline),
   );
 
   const normalRules: ProcessedStyleRules[] = [];


### PR DESCRIPTION
## Summary

The declaration guard created in `getDeclarations` captures that function's environment rather than the three values it compares. What ends up in the environment depends on the Hermes optimisation level, which differs between dev and release builds (`react-native-xcode.sh` passes `-Og` when `DEV == true`, `-O` otherwise):

| | closure environment of the inline guard |
|---|---|
| `-Og` (dev) | `this`, `new.target`, `previousState`, `refs`, `action`, `config`, `state`, `guards` |
| `-O` (release) | `config`, `state` |

Verified by dumping the IR of a reduced case with the bundled `hermesc` (`hermesc -dump-ir -Og` / `-O`).

Under `-Og` the environment holds `previousState`, so every render links its state to the previous one and the chain grows by one link per render — nothing from earlier renders can be collected. Under `-O` there is no generational chain, but the guard still pins that render's `state` for as long as the tracking object lives.

```
state_N ──declarationTracking──▶ tracking_N ──guards[0]──▶ guard_N
                                                             │ environment
                                                             ▼
                                              { state_N, previousState = state_N-1 }
                                                             │
state_N-1 ──declarationTracking──▶ tracking_N-1 ──▶ guard_N-1 ──▶ state_N-2 ──▶ …
```

Resetting `guards: []` in the new state does not break this — the array is new, but the closures already created still hold the environment. Because each retained state also holds that render's `props` (and therefore its children element tree), the whole render history stays alive under `-Og`.

Any screen that re-renders on a timer or subscription grows without bound. The measurements below are from a dev build; that is where the unbounded growth shows up.

## Diagnosis

Measured on a physical iPhone 11 Pro, RN 0.86.0, react 19.2.3, Hermes, New Architecture, `nativewind@4.2.6` / `react-native-css-interop@0.2.6`. The screen under test re-renders once per second (a countdown value held in the screen's top-level state).

### Hermes heap, before the fix

`HermesInternal.getInstrumentedStats()` after ~14 minutes on that screen:

```
js_heapSize            390 MB
js_allocatedBytes      376 MB   ← live after GC
js_numGCs            6,772
js_totalAllocatedBytes  23.9 GB   ← cumulative churn
```

376 MB of *live* objects on a screen showing two profile cards and a few sections. The collector ran 6,772 times without reclaiming any of it — the retained set is reachable, so GC cannot help.

### What is retained

Heap snapshots taken through the Metro inspector (`HeapProfiler.takeHeapSnapshot`), retaining paths resolved by walking the snapshot graph from the GC roots:

| | before | after this change |
|---|---|---|
| Snapshot size | 528 MB | 61 MB |
| Total nodes | 3,699,961 | 466,887 |
| React elements | 171,857 | 2,657 |
| `ReducerState` objects | 60,796 | not in top 30 |
| `CssInterop.Text` elements | 38,654 | 393 |
| One screen section's elements | 564 (= render count) | 0 |
| `FiberNode` | 6,995 | 4,573 |

The retaining path repeated a 5-node unit — `ReducerState → declarationTracking → guards → guard closure → Environment → previous ReducerState` — to a depth of 2,000–2,800, matching `render count (564) × 5`. `FiberNode` count stayed normal throughout, so the mounted tree was never the problem; the chain of past `ReducerState`s was.

(The "before" snapshot was taken ~14 min into the session and the "after" one ~4 min in, so the two are not time-matched. The difference is far larger than that gap explains: at one render per second, 4 minutes would still be ~240 renders, which under the old behaviour left ~70k retained elements, not 2,657. What changes is that per-render state stops accumulating at all.)

### Process memory

Same screen, left untouched after a reload:

| | memory growth |
|---|---|
| before | **60.7 MB/min** |
| after | **7.5 MB/min** |

Before the fix the app was killed by iOS jetsam after ~22 minutes on that screen:

```
kernel: memorystatus: killing process [datingApp] in high band FOREGROUND (100)
kernel: killing_specific_process ... 2148100KB
SpringBoard: Process exited: jetsam(1) code:per-process-limit(7)
```

## Reproduction

1. Render any `nativewind`-styled screen whose top-level state updates on an interval (e.g. `setInterval(() => setTimeLeft(...), 1000)`).
2. Leave it in the foreground.
3. Watch `HermesInternal.getInstrumentedStats().js_allocatedBytes`, or take a heap snapshot and count `JSObject(config, className, props, normal, important, ...)` nodes — one set accumulates per render and is never released.

## Notes

- v5 is unaffected: guards there are plain data tuples (`["a", name, value]`), so there is no environment to capture.
- Touches the same file as #1840 but a different region (guard creation vs. `inlineProp` / `applyStyles`), so the two should not conflict.
- No behaviour change: the guard compares the same three values as before.
