### PR TITLE
fix: point the ./metro source condition at the file it names

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
       "types": "./dist/typescript/commonjs/src/babel.d.ts"
     },
     "./metro": {
-      "source": "./src/metro.ts",
+      "source": "./src/metro.tsx",
       "import": {
         "types": "./dist/typescript/module/src/metro.d.ts",
         "default": "./dist/module/metro.js"

--- a/src/__tests__/package-exports.ts
+++ b/src/__tests__/package-exports.ts
@@ -1,0 +1,125 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Every path the manifest declares names a file that exists.
+ *
+ * An export condition matches on KEY PRESENCE, not on whether its target resolves, so a target that
+ * names a missing file is `ERR_MODULE_NOT_FOUND` rather than a fallthrough to the next condition.
+ * That makes a typo in one condition invisible to every consumer who does not enable it — which is
+ * how `"./metro"`'s `source` target came to name `./src/metro.ts` for a module authored `.tsx`.
+ */
+
+const PACKAGE_ROOT = join(__dirname, "..", "..");
+
+interface DeclaredTarget {
+  readonly subpath: string;
+  readonly condition: string;
+  readonly target: string;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const manifest: unknown = JSON.parse(
+  readFileSync(join(PACKAGE_ROOT, "package.json"), "utf8"),
+);
+
+if (!isRecord(manifest)) {
+  throw new Error("package.json is not an object");
+}
+
+/** Every leaf string under a condition tree, tagged with the conditions that reach it. */
+const collectConditionTargets = (
+  value: unknown,
+  conditions: readonly string[] = [],
+): readonly (readonly [string, string])[] => {
+  if (typeof value === "string") {
+    return [
+      [conditions.length === 0 ? "(direct)" : conditions.join("."), value],
+    ];
+  }
+
+  if (!isRecord(value)) {
+    return [];
+  }
+
+  return Object.entries(value).flatMap(([condition, nested]) =>
+    collectConditionTargets(nested, [...conditions, condition]),
+  );
+};
+
+const exportsMap: unknown = manifest.exports;
+
+const declaredTargets: readonly DeclaredTarget[] = [
+  ...(["main", "module", "types"] as const).flatMap(
+    (field): readonly DeclaredTarget[] =>
+      typeof manifest[field] === "string"
+        ? [{ subpath: field, condition: "(direct)", target: manifest[field] }]
+        : [],
+  ),
+  ...(isRecord(exportsMap)
+    ? Object.entries(exportsMap).flatMap(([subpath, value]) =>
+        collectConditionTargets(value).map(
+          ([condition, target]): DeclaredTarget => ({
+            subpath: `exports["${subpath}"]`,
+            condition,
+            target,
+          }),
+        ),
+      )
+    : []),
+];
+
+/**
+ * The build output directory, read from bob's own config rather than spelled again here — the split
+ * below is "is this target checked in or generated", and bob is what decides that.
+ */
+const builderBobConfig: unknown = manifest["react-native-builder-bob"];
+const buildOutputDirectory: string =
+  isRecord(builderBobConfig) && typeof builderBobConfig.output === "string"
+    ? builderBobConfig.output
+    : "dist";
+
+const isBuildOutput = ({ target }: DeclaredTarget): boolean =>
+  target.replace(/^\.\//, "").startsWith(`${buildOutputDirectory}/`);
+
+const checkedInTargets = declaredTargets.filter(
+  (entry) => !isBuildOutput(entry),
+);
+const builtTargets = declaredTargets.filter(isBuildOutput);
+
+const describeMissing = (
+  targets: readonly DeclaredTarget[],
+): readonly string[] =>
+  targets
+    .filter(({ target }) => !existsSync(join(PACKAGE_ROOT, target)))
+    .map(
+      ({ subpath, condition, target }) =>
+        `${subpath} [${condition}] -> ${target}`,
+    );
+
+describe("package.json declares only reachable targets", () => {
+  // Both censuses are derived from the manifest, so an `exports` map that stopped being read would
+  // leave every assertion below vacuously true. These are what make that a failure.
+  test("the manifest declares checked-in targets to verify", () => {
+    expect(checkedInTargets.length).toBeGreaterThan(0);
+  });
+
+  test("the manifest declares build-output targets to verify", () => {
+    expect(builtTargets.length).toBeGreaterThan(0);
+  });
+
+  test("every checked-in target exists", () => {
+    expect(describeMissing(checkedInTargets)).toStrictEqual([]);
+  });
+
+  // Only meaningful once `yarn build` has run; CI builds before it tests, and `prepublishOnly`
+  // builds before it publishes, so the case that matters is covered either way.
+  const buildHasRun = existsSync(join(PACKAGE_ROOT, buildOutputDirectory));
+  const testBuiltTargets = buildHasRun ? test : test.skip;
+
+  testBuiltTargets("every build-output target exists", () => {
+    expect(describeMissing(builtTargets)).toStrictEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem

`exports["./metro"]` declares a `source` condition pointing at `./src/metro.ts`, but the module is authored `src/metro.tsx`:

```json
"./metro": {
  "source": "./src/metro.ts",
  "import":  { "types": "./dist/typescript/module/src/metro.d.ts",   "default": "./dist/module/metro.js" },
  "require": { "types": "./dist/typescript/commonjs/src/metro.d.ts", "default": "./dist/commonjs/metro.js" }
}
```

An export condition matches on **key presence, not on whether its target resolves**, so there is no fallthrough to `import` / `require` — resolution stops at the missing file:

```console
$ node --conditions=source --input-type=module -e "import('nativewind/metro')"
ERR_MODULE_NOT_FOUND: Cannot find module '.../node_modules/nativewind/src/metro.ts'
```

## Who hits it

`source` is not an obscure condition — it is the one `react-native-monorepo-config`'s `withMetroConfig` turns on so a monorepo consumes library **source** rather than `dist`:

```js
// react-native-monorepo-config/index.js
mainFields: ['source', ...context.mainFields],
unstable_conditionNames: ['source', ...context.unstable_conditionNames],
```

That is the package this repo's own `example/` lists as a devDependency, and the setup `react-native-builder-bob` documents for library development. Under it, `withNativewind` — the entry that configures Metro — is the one entry that cannot be imported.

`./metro` is also the only entry carrying a `source` condition at all, which is why nothing else in the manifest fails the same way.

## Fix

Point the condition at the file that exists. `.tsx` matches the rest of the tree — `babel.tsx`, `index.tsx`, `plugin.tsx` and `metro.tsx` are all `.tsx` regardless of whether they contain JSX — so this corrects the manifest rather than renaming a source file out of the house convention.

Verified against the branch:

```console
$ node --conditions=source --input-type=module -e "import.meta.resolve('nativewind/metro')"
file:///.../nativewind/src/metro.tsx
```

## Guard

This is the third broken export target in this manifest: #1638 fixed `.` and `./babel`, #1723 fixed `./types`, and each was found by a consumer rather than by CI. The defect is invisible to the test suite, to `tsc`, and to `eslint`, because none of them resolve the manifest — and invisible to any consumer who does not enable the affected condition.

So the PR adds `src/__tests__/package-exports.ts`, which walks every path the manifest declares — `main`, `module`, `types`, and every leaf of the `exports` condition tree — and asserts each names a file that exists. It derives the census from the manifest rather than listing entries, so a new export is covered the moment it is added, and asserts the census is non-empty so a manifest that stopped being read fails instead of passing vacuously.

Build-output targets are separated from checked-in ones using bob's own `react-native-builder-bob.output` value, and are checked only once a build has run — CI builds before it tests and `prepublishOnly` builds before it publishes, so the publishing path is covered either way, while a fresh clone running `yarn test` is not red for an unrelated reason.

Mutation-proved: with the manifest reverted to `./src/metro.ts`, the guard fails with

```
- Array []
+ Array [
+   "exports[\"./metro\"] [source] -> ./src/metro.ts",
+ ]
```

and the other three cases stay green.

## Quality gates

| Command | Result |
| --- | --- |
| `yarn lint` | clean |
| `yarn typecheck` | clean |
| `yarn test --maxWorkers=2` | 8 suites, 39 tests, all passing |
